### PR TITLE
Refactor workspace metadata test setup

### DIFF
--- a/tests/helpers/workspace_metadata.py
+++ b/tests/helpers/workspace_metadata.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-__all__ = ["_build_test_package", "_create_test_manifest"]
+__all__ = ["build_test_package", "create_test_manifest"]
 
 import textwrap
 import typing as typ
@@ -11,7 +11,14 @@ if typ.TYPE_CHECKING:
     from pathlib import Path
 
 
-def _create_test_manifest(workspace_root: Path, crate_name: str, content: str) -> Path:
+class PackageKwargs(typ.TypedDict, total=False):
+    """Optional arguments accepted by :func:`build_test_package`."""
+
+    dependencies: list[dict[str, str]]
+    publish: list[str] | None
+
+
+def create_test_manifest(workspace_root: Path, crate_name: str, content: str) -> Path:
     """Write a manifest for ``crate_name`` beneath ``workspace_root``."""
     manifest_dir = workspace_root / crate_name
     manifest_dir.mkdir(parents=True)
@@ -20,11 +27,11 @@ def _create_test_manifest(workspace_root: Path, crate_name: str, content: str) -
     return manifest_path
 
 
-def _build_test_package(
+def build_test_package(
     name: str,
     version: str,
     manifest_path: Path,
-    **kwargs: object,
+    **kwargs: typ.Unpack[PackageKwargs],
 ) -> dict[str, typ.Any]:
     """Create package metadata with predictable identifiers for tests.
 

--- a/tests/unit/test_workspace_metadata.py
+++ b/tests/unit/test_workspace_metadata.py
@@ -21,7 +21,7 @@ from lading.workspace import (
 )
 from lading.workspace import metadata as metadata_module
 from tests.helpers.workspace_helpers import install_cargo_stub
-from tests.helpers.workspace_metadata import _build_test_package, _create_test_manifest
+from tests.helpers.workspace_metadata import build_test_package, create_test_manifest
 
 _METADATA_PAYLOAD: typ.Final[dict[str, typ.Any]] = {
     "workspace_root": "./",
@@ -187,7 +187,7 @@ def test_ensure_command_raises_on_missing_executable(
 def test_build_workspace_graph_constructs_models(tmp_path: Path) -> None:
     """Convert metadata payloads into strongly typed workspace models."""
     workspace_root = tmp_path
-    crate_manifest = _create_test_manifest(
+    crate_manifest = create_test_manifest(
         workspace_root,
         "crate",
         """
@@ -200,7 +200,7 @@ def test_build_workspace_graph_constructs_models(tmp_path: Path) -> None:
         helper = { path = "../helper", version = "0.1.0" }
         """,
     )
-    helper_manifest = _create_test_manifest(
+    helper_manifest = create_test_manifest(
         workspace_root,
         "helper",
         """
@@ -213,7 +213,7 @@ def test_build_workspace_graph_constructs_models(tmp_path: Path) -> None:
     metadata = {
         "workspace_root": str(workspace_root),
         "packages": [
-            _build_test_package(
+            build_test_package(
                 "crate",
                 "0.1.0",
                 crate_manifest,
@@ -223,7 +223,7 @@ def test_build_workspace_graph_constructs_models(tmp_path: Path) -> None:
                 ],
                 publish=[],
             ),
-            _build_test_package(
+            build_test_package(
                 "helper",
                 "0.1.0",
                 helper_manifest,


### PR DESCRIPTION
## Summary
- add helper functions for creating manifests and package metadata in workspace metadata tests
- refactor the workspace graph construction test to use the shared helpers

## Testing
- make test

------
https://chatgpt.com/codex/tasks/task_e_68f0398f0bc483229beafb66abb0eb00

## Summary by Sourcery

Refactor workspace metadata tests by extracting common manifest and package creation logic into helper functions and applying them in the workspace graph construction test for improved readability and maintainability.

Enhancements:
- Introduce shared helper functions to create test manifests and package metadata for workspace tests

Tests:
- Refactor the workspace graph construction test to utilize the new helpers for manifest and package setup

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added centralized test helpers for creating workspace manifests and deterministic package metadata; updated unit tests to use these helpers while preserving prior test behavior and assertions.

Note: Internal test tooling improvements only — no changes to user-facing functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->