### PR TITLE
Enforce Ruff complexity and argument limits

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -83,15 +83,20 @@ select = [
     "EM",
     "D",
     "ANN",
+    "C90",
+    "PLR0913",
 ]
 extend-ignore = [
     "D203",  # Conflicts with D211; prefer enforcing no blank line before class docstring.
     "D213",  # Conflicts with D212; keep summary on the first line.
 ]
-per-file-ignores = {"**/test_*.py" = ["S101"]}
+per-file-ignores = {"**/test_*.py" = ["S101", "PLR0913"]}
 
 [tool.ruff.lint.mccabe]
 max-complexity = 9
+
+[tool.ruff.lint.pylint]
+max-args = 4
 
 [tool.ruff.lint.flake8-import-conventions]
 # Declare the banned `from` imports.

--- a/tests/helpers/workspace_builders.py
+++ b/tests/helpers/workspace_builders.py
@@ -45,25 +45,18 @@ def _write_workspace_manifest(root: Path, members: tuple[str, ...]) -> Path:
     return manifest
 
 
-def _write_crate_manifest(
-    manifest_path: Path,
-    *,
-    name: str,
-    version: str,
-    extra_sections: str = "",
-    include_workspace_readme: bool = False,
-) -> None:
-    """Write a crate manifest with optional dependency sections."""
+def _write_crate_manifest(manifest_path: Path, spec: _CrateSpec) -> None:
+    """Write a crate manifest based on the provided crate specification."""
     header_lines = [
         "[package]",
-        f'name = "{name}"',
-        f'version = "{version}"',
+        f'name = "{spec.name}"',
+        f'version = "{spec.version}"',
     ]
-    if include_workspace_readme:
+    if spec.readme_workspace:
         header_lines.append("readme.workspace = true")
     content = "\n".join(header_lines) + "\n"
-    if extra_sections:
-        content += "\n" + textwrap.dedent(extra_sections).strip() + "\n"
+    if spec.manifest_extra:
+        content += "\n" + textwrap.dedent(spec.manifest_extra).strip() + "\n"
     manifest_path.write_text(content, encoding="utf-8")
 
 
@@ -86,13 +79,7 @@ def _build_workspace_with_internal_deps(
         crate_dir = root / "crates" / spec.name
         crate_dir.mkdir(parents=True, exist_ok=True)
         manifest_path = crate_dir / "Cargo.toml"
-        _write_crate_manifest(
-            manifest_path,
-            name=spec.name,
-            version=spec.version,
-            extra_sections=spec.manifest_extra,
-            include_workspace_readme=spec.readme_workspace,
-        )
+        _write_crate_manifest(manifest_path, spec)
         manifests[spec.name] = manifest_path
         crates.append(
             WorkspaceCrate(

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -109,14 +109,14 @@ def make_workspace(
 
 @pytest.fixture
 def publish_fixtures(
-    tmp_path: Path,
-    make_crate: typ.Callable[[Path, str, _CrateSpec | None], WorkspaceCrate],
-    make_workspace: typ.Callable[[Path, WorkspaceCrate], WorkspaceGraph],
-    make_config: typ.Callable[..., config_module.LadingConfig],
-    make_dependency: typ.Callable[[str], WorkspaceDependency],
-    publish_options: publish.PublishOptions,
+    request: pytest.FixtureRequest, publish_options: publish.PublishOptions
 ) -> PublishFixtures:
     """Return the composite publish fixtures used across unit suites."""
+    tmp_path: Path = request.getfixturevalue("tmp_path")
+    make_crate = request.getfixturevalue("make_crate")
+    make_workspace = request.getfixturevalue("make_workspace")
+    make_config = request.getfixturevalue("make_config")
+    make_dependency = request.getfixturevalue("make_dependency")
     return PublishFixtures(
         tmp_path=tmp_path,
         make_crate=make_crate,


### PR DESCRIPTION
## Summary
- enable Ruff's C90 and PLR0913 checks and configure max arguments with targeted test exemptions
- refactor test workspace manifest helper to derive metadata from crate specifications
- adjust publish fixture assembly to pull dependencies from pytest's request object and stay within argument limits

## Testing
- make check-fmt
- make typecheck
- make lint
- make test

------
https://chatgpt.com/codex/tasks/task_e_6906190604748322b063d246911e8341

## Summary by Sourcery

Enforce code complexity and argument limits via Ruff while refactoring test helpers to derive metadata from CrateSpec and streamline fixture assembly through pytest request

New Features:
- Enable Ruff C90 and PLR0913 checks with configured max-complexity and max-args thresholds

Enhancements:
- Refactor `_write_crate_manifest` to accept a CrateSpec object for deriving manifest metadata
- Simplify `publish_fixtures` by retrieving fixtures via pytest's request object to reduce direct arguments

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated linting configuration to enforce additional code quality rules.
  * Refactored internal test infrastructure for improved maintainability and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->