### PR TITLE
Fix cargo shim argument placement

### DIFF
--- a/scripts/publish-check/bin/cargo
+++ b/scripts/publish-check/bin/cargo
@@ -35,6 +35,7 @@ _OPTIONS_CONSUMING_VALUE = {
     "--message-format",
     "--profile",
     "--target",
+    "--target-dir",
     "--timings",
     "--jobs",
     "--unit-graph",

--- a/tests/integration/__init__.py
+++ b/tests/integration/__init__.py
@@ -1,0 +1,1 @@
+"""Integration test package for publish-check."""

--- a/tests/integration/test_cargo_shim_cli.py
+++ b/tests/integration/test_cargo_shim_cli.py
@@ -1,10 +1,13 @@
+"""Integration tests for the publish-check cargo shim CLI."""
+
+# ruff: noqa: D103, S603
+
 from __future__ import annotations
 
 import json
 import os
 import subprocess
 from pathlib import Path
-
 
 SCRIPT_PATH = (
     Path(__file__).resolve().parents[2] / "scripts" / "publish-check" / "bin" / "cargo"
@@ -57,3 +60,22 @@ def test_cli_forwards_additional_arguments(tmp_path: Path) -> None:
     assert process.returncode == 0
     args = json.loads(process.stdout.strip())
     assert args == ["+nightly", "bench", "--all-features", "--", "foo"]
+
+
+def test_cli_preserves_global_option_values(tmp_path: Path) -> None:
+    _make_fake_cargo(tmp_path)
+    env = os.environ.copy()
+    env["PATH"] = os.pathsep.join([str(tmp_path), env.get("PATH", "")])
+    process = subprocess.run(
+        [str(SCRIPT_PATH), "--target-dir", "ci-target", "test"],
+        check=False,
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+
+    assert process.returncode == 0
+    stdout = process.stdout.strip()
+    assert stdout
+    args = json.loads(stdout)
+    assert args == ["--target-dir", "ci-target", "test", "--all-features"]


### PR DESCRIPTION
## Summary
- ensure the publish-check cargo wrapper injects `--all-features` before any `--` separator so Cargo always receives the flag
- add unit coverage for the shim to cover separators, duplicates, and common global option scenarios

## Testing
- make test

------
https://chatgpt.com/codex/tasks/task_e_6909a3ec8d70832299d6a4dc1ca22261

## Summary by Sourcery

Enforce correct placement of the --all-features flag in the publish-check cargo shim and validate behavior with unit tests.

Enhancements:
- Inject --all-features before any -- separator or append it when no separator is present
- Preserve existing --all-features flags and skip injection for non-target commands

Tests:
- Add unit tests covering flag insertion before and after separators, duplicate handling, non-target commands, and global option scenarios

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added a CLI wrapper that ensures targeted cargo commands are always run with --all-features.

* **Tests**
  * Added unit tests for the argument rewriting logic and integration tests exercising the CLI behavior with a fake cargo executable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->