### PR TITLE
Refactor preflight tests and normalize excludes

### DIFF
--- a/lading/commands/publish.py
+++ b/lading/commands/publish.py
@@ -665,6 +665,11 @@ def _preflight_argument_sets(
     return check_arguments, test_arguments
 
 
+def _normalise_test_excludes(entries: typ.Sequence[str]) -> tuple[str, ...]:
+    """Return sorted, deduplicated, trimmed crate names for ``--exclude`` flags."""
+    return tuple(sorted({crate.strip() for crate in entries if crate.strip()}))
+
+
 def _build_test_arguments(
     base_arguments: list[str], options: _CargoPreflightOptions
 ) -> list[str]:
@@ -672,10 +677,7 @@ def _build_test_arguments(
     arguments = list(base_arguments)
     if options.unit_tests_only:
         arguments.extend(("--lib", "--bins"))
-    normalized_excludes = sorted(
-        {crate.strip() for crate in options.test_excludes if crate.strip()}
-    )
-    for crate_name in normalized_excludes:
+    for crate_name in _normalise_test_excludes(options.test_excludes):
         # Sorted unique values keep cargo invocations deterministic for tests/logging.
         arguments.extend(("--exclude", crate_name))
     return arguments

--- a/tests/unit/publish/preflight_test_utils.py
+++ b/tests/unit/publish/preflight_test_utils.py
@@ -25,7 +25,7 @@ def _setup_preflight_test(
     configuration: config_module.LadingConfig,
     crate_names: typ.Sequence[str] | None = None,
 ) -> tuple[Path, WorkspaceGraph, RecordedCommands]:
-    """Execute ``publish.run`` with optional crates and capture cargo invocations."""
+    """Execute ``publish.run`` with optional workspace crates and capture calls."""
     monkeypatch.setattr(publish, "_run_preflight_checks", ORIGINAL_PREFLIGHT)
     root = tmp_path / "workspace"
     root.mkdir()

--- a/tests/unit/publish/test_preflight_arguments.py
+++ b/tests/unit/publish/test_preflight_arguments.py
@@ -28,6 +28,17 @@ def test_build_test_arguments_does_not_mutate_base_list() -> None:
     assert base == ["--workspace"]
 
 
+def test_build_test_arguments_with_no_unit_tests_and_no_excludes() -> None:
+    """Empty options should preserve the base argument ordering."""
+    base = ["--workspace"]
+    options = _make_options(unit_tests_only=False, test_excludes=())
+
+    result = publish._build_test_arguments(base, options)
+
+    assert result is not base
+    assert result == ["--workspace"]
+
+
 def test_build_test_arguments_appends_unit_test_flags_before_excludes() -> None:
     """Unit tests only mode inserts lib/bin flags ahead of exclusions."""
     base = ["--workspace"]
@@ -49,3 +60,27 @@ def test_build_test_arguments_ignores_blank_excludes() -> None:
     result = publish._build_test_arguments(base, options)
 
     assert "--exclude" not in result
+
+
+def test_build_test_arguments_skips_blank_entries_with_valid_names() -> None:
+    """Only the meaningful crate names produce --exclude flags."""
+    base = ["--workspace"]
+    options = _make_options(test_excludes=("  ", "alpha", "", "beta"))
+
+    result = publish._build_test_arguments(base, options)
+
+    assert result[-4:] == ["--exclude", "alpha", "--exclude", "beta"]
+
+
+def test_normalise_test_excludes_sorts_and_deduplicates() -> None:
+    """The normalization helper returns trimmed, sorted unique names."""
+    entries = (" beta", "alpha ", "alpha", "gamma")
+
+    assert publish._normalise_test_excludes(entries) == ("alpha", "beta", "gamma")
+
+
+def test_normalise_test_excludes_handles_empty_values() -> None:
+    """Blank strings are ignored when normalizing test excludes."""
+    entries = ("", " \t", "alpha", "", "beta")
+
+    assert publish._normalise_test_excludes(entries) == ("alpha", "beta")


### PR DESCRIPTION
## Summary
- Normalize and deduplicate test excludes in preflight cargo test invocations to make test runs deterministic.
- Introduce shared test utilities for publish preflight tests.
- Add unit tests for the preflight argument builder and update integration tests to leverage new helpers.

## Changes

### Core Functionality
- lading/commands/publish.py
  - _build_test_arguments now trims whitespace, deduplicates, and sorts test_excludes before appending --exclude in a deterministic order.

### Tests
- New: tests/unit/publish/preflight_test_utils.py
  - _setup_preflight_test: sets up a workspace, hooks preflight checks, and records cargo invocations.
  - _extract_cargo_test_call: extracts the cargo test invocation from recorded calls.
- New: tests/unit/publish/test_preflight_arguments.py
  - Tests for _build_test_arguments:
    - Ensures base list is not mutated.
    - In unit_tests_only mode, appends --lib and --bins before any --exclude entries and normalizes excludes.
    - Ignores blank/whitespace-only excludes.
- Updated: tests/unit/publish/test_run_integration.py
  - Uses shared preflight test utilities for setup and cargo call extraction.
  - Parametrized tests verify normalization behavior of excludes (order, trimming, deduplication).
  - Verifies that in unit-tests-only mode, excludes are omitted and --lib/--bins are present, with deterministic target handling.
  - Removed duplicated helper definitions by moving them to preflight_test_utils.py and importing where needed.

## Test plan
- [x] Run unit tests for preflight argument construction (test_preflight_arguments.py)
- [x] Run integration tests verifying preflight exclude normalization and unit-test-only behavior (test_run_integration.py)
- [x] Ensure cargo test invocations are deterministic across runs due to sorting and deduplication of excludes


🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/9bd1a2a6-c740-44e4-abbd-850656f45bf3

## Summary by Sourcery

Refactor preflight test argument construction to trim, dedupe, and sort excludes for deterministic cargo invocations; extract common test setup and invocation helpers into a shared module; and add unit and integration tests to verify the new behavior.

Enhancements:
- Normalize and deduplicate preflight test excludes in cargo test invocations for deterministic ordering
- Introduce shared test utilities to set up and extract preflight cargo test calls

Tests:
- Add unit tests for _build_test_arguments to validate base list immutability, exclude trimming, deduplication, ordering, and unit-tests-only behavior
- Refactor integration tests to leverage shared preflight helpers and parameterize exclude normalization and unit-tests-only mode

Chores:
- Remove duplicated helper definitions by moving them into a shared preflight_test_utils module