### PR TITLE
Handle missing lading.toml by using defaults in cyclopts

### DIFF
--- a/docs/lading-design.md
+++ b/docs/lading-design.md
@@ -125,8 +125,10 @@ lading [--workspace-root <path>] <subcommand> [options]
 
 ### 2.2. Configuration: `lading.toml`
 
-A `lading.toml` file located at the workspace root will define the tool's
-behaviour. The design prioritises inference to keep this file as minimal as
+A `lading.toml` file located at the workspace root defines the tool's
+behaviour. When the file is absent the CLI treats it as an empty document and
+runs with the default configuration, so workspaces can opt in to overrides
+incrementally. The design prioritises inference to keep this file as minimal as
 possible.
 
 **Schema Definition:**

--- a/docs/usage-guide.md
+++ b/docs/usage-guide.md
@@ -54,11 +54,13 @@ When the variable is unset, the CLI retains the default `INFO` level.
 
 ## Configuration file: `lading.toml`
 
-`lading` expects a `lading.toml` file at the workspace root. The CLI resolves
-the workspace directory, uses `cyclopts`' TOML loader to read the file, and
-exposes the resulting configuration to the active command. The configuration is
-validated with a dataclass-backed model to ensure that string lists and boolean
-flags conform to the schema described in the design document.
+`lading` looks for a `lading.toml` file at the workspace root. When the file is
+present the CLI resolves the workspace directory, uses `cyclopts`' TOML loader
+to read the file, and exposes the resulting configuration to the active
+command. If the file is absent the loader now returns an empty document, so the
+commands run with the default configuration. The configuration is validated
+with a dataclass-backed model to ensure that string lists and boolean flags
+conform to the schema described in the design document.
 
 An example minimal configuration looks like:
 
@@ -72,11 +74,10 @@ globs = ["README.md", "docs/**/*.md"]
 strip_patches = "all"
 ```
 
-If the file is missing or contains invalid values the CLI prints a descriptive
-error and exits with a non-zero status. Commands invoked programmatically via
+If the file contains invalid values the CLI prints a descriptive error and
+exits with a non-zero status. Commands invoked programmatically via
 `python -m lading.cli` load the configuration on demand, so helper scripts and
-tests can continue to exercise the commands directly as long as the file is
-present.
+tests can rely on the default behaviour when `lading.toml` is not supplied.
 
 ## Subcommands
 

--- a/lading/config.py
+++ b/lading/config.py
@@ -189,7 +189,7 @@ def build_loader(workspace_root: Path) -> Toml:
     resolved = normalise_workspace_root(workspace_root)
     return Toml(
         path=resolved / CONFIG_FILENAME,
-        must_exist=True,
+        must_exist=False,
         search_parents=False,
         allow_unknown=True,
         use_commands_as_keys=True,
@@ -200,10 +200,6 @@ def load_from_loader(loader: Toml) -> LadingConfig:
     """Load and validate configuration using ``loader``."""
     try:
         raw = loader.config
-    except FileNotFoundError as exc:
-        missing_path = exc.filename or str(loader.path)
-        message = f"Configuration file not found: {missing_path}"
-        raise MissingConfigurationError(message) from exc
     except ValueError as exc:
         raise ConfigurationError(str(exc)) from exc
     if not isinstance(raw, cabc.Mapping):

--- a/tests/bdd/features/cli.feature
+++ b/tests/bdd/features/cli.feature
@@ -193,5 +193,8 @@ Feature: Lading CLI scaffolding
 
   Scenario: Running the bump command without configuration
     Given a workspace directory without configuration
+    And cargo metadata describes a sample workspace
     When I invoke lading bump 1.2.3 with that workspace
-    Then the CLI reports a missing configuration error
+    Then the bump command reports manifest updates for "1.2.3"
+    And the workspace manifest version is "1.2.3"
+    And the crate "alpha" manifest version is "1.2.3"

--- a/tests/bdd/steps/test_common_steps.py
+++ b/tests/bdd/steps/test_common_steps.py
@@ -11,8 +11,6 @@ from pytest_bdd import parsers, scenarios, then
 from tomlkit import parse as parse_toml
 from tomlkit.items import InlineTable, Item, Table
 
-from lading import config as config_module
-
 from . import config_fixtures as _config_fixtures  # noqa: F401
 from . import manifest_fixtures as _manifest_fixtures  # noqa: F401
 from . import metadata_fixtures as _metadata_fixtures  # noqa: F401
@@ -174,17 +172,6 @@ def _then_dependency_requirement_step(
             section=section,
             expected_requirement=expected,
         ),
-    )
-
-
-@then("the CLI reports a missing configuration error")
-def then_cli_reports_missing_configuration(cli_run: dict[str, typ.Any]) -> None:
-    """Assert the CLI surfaces missing configuration errors."""
-    assert cli_run["returncode"] == 1
-    stderr = cli_run["stderr"]
-    expected_path = cli_run["workspace"] / config_module.CONFIG_FILENAME
-    assert (
-        f"Configuration error: Configuration file not found: {expected_path}" in stderr
     )
 
 

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -140,10 +140,11 @@ def test_load_configuration_applies_defaults(tmp_path: Path) -> None:
     assert configuration.preflight.unit_tests_only is False
 
 
-def test_load_configuration_requires_file(tmp_path: Path) -> None:
-    """Raise a descriptive error when ``lading.toml`` is absent."""
-    with pytest.raises(config_module.MissingConfigurationError):
-        config_module.load_configuration(tmp_path)
+def test_load_configuration_defaults_without_file(tmp_path: Path) -> None:
+    """Missing configuration files fall back to the default configuration."""
+    configuration = config_module.load_configuration(tmp_path)
+
+    assert configuration == config_module.LadingConfig()
 
 
 def test_preflight_config_from_mapping_parses_fields() -> None:


### PR DESCRIPTION
## Summary
- Make cyclopts gracefully handle a missing lading.toml by treating it as an empty document and falling back to default configuration.
- Remove the explicit missing-configuration error path; commands now run with defaults when no config file is present.

## Changes
- lading/config.py
  - Toml loader: `must_exist` changed from `True` to `False` so a missing config file yields an empty document instead of an error.
  - `load_from_loader` no longer raises on `FileNotFoundError`; missing files now result in default configuration being used.
- Documentation
  - docs/lading-design.md: Update phrasing to reflect that a missing `lading.toml` results in default behavior.
  - docs/usage-guide.md: Clarify that when `lading.toml` is absent, the loader returns an empty document and commands run with defaults; tests and programmatic usage can rely on defaults when the file is not supplied.
- Tests
  - tests/unit/test_config.py
    - Rename/add test to verify defaults when the configuration file is absent (`test_load_configuration_defaults_without_file`).
  - tests/unit/test_cli.py
    - Update to `test_main_uses_defaults_when_configuration_missing`: CLI falls back to defaults when no config file exists; verify workspace, version, and default config usage.
  - tests/bdd/steps/test_common_steps.py
    - Remove the previous missing-configuration error step; align with new behavior where missing config uses defaults.
  - tests/bdd/features/cli.feature
    - Update scenario to reflect that bump with no configuration still updates manifests (no error) when workspace has no lading.toml.

## Rationale
- This change simplifies usage by allowing workspaces to opt-in to configuration overrides incrementally. If lading.toml is absent, users get sensible defaults and non-breaking CLI behavior.

## Migration / Backwards Compatibility
- Non-breaking: existing workflows that rely on defaults when no lading.toml is present will continue to work. If a project previously expected an error on missing config, that behavior is removed in favor of defaults.

## How to test
- Run unit tests: ensure tests related to missing configuration pass with defaults.
- Run BDD tests: execute scenarios where a workspace lacks lading.toml and verify that commands (e.g., bump) update manifests or report using defaults rather than failing due to missing config.
- Manual check: remove or rename lading.toml in a workspace and run a simple command to confirm it operates with default settings.


🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/8c05f2dc-96e8-456c-bafd-d9db82e0ff32

## Summary by Sourcery

Allow workspace commands to run with sensible defaults when lading.toml is absent by disabling the missing-file error path and treating a missing configuration as an empty document.

New Features:
- Fall back to default configuration when lading.toml is missing instead of erroring

Enhancements:
- Remove explicit missing-configuration error path in loader and treat absent config as empty document

Documentation:
- Update design and usage documentation to describe default behavior for missing lading.toml

Tests:
- Update unit and BDD tests to verify commands run with defaults when no configuration file exists

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The configuration file (lading.toml) is now optional. When absent, the tool uses default configuration and runs successfully instead of failing, enabling opt-in configuration for workspaces.

* **Documentation**
  * Updated configuration guides to reflect optional file handling and default configuration behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->