### PR TITLE
Refactor and enhance preflight test configurations and fixtures

### DIFF
--- a/lading/config.py
+++ b/lading/config.py
@@ -257,9 +257,11 @@ def _string_tuple(value: object, field_name: str) -> tuple[str, ...]:
     if value is None:
         return ()
     if isinstance(value, str):
-        return (value,)
+        stripped = value.strip()
+        return (stripped,) if stripped else ()
     if isinstance(value, cabc.Sequence) and not isinstance(value, str | bytes):
-        return _validate_string_sequence(value, field_name)
+        validated = _validate_string_sequence(value, field_name)
+        return tuple(stripped for entry in validated if (stripped := entry.strip()))
     message = (
         f"{field_name} must be a string or a sequence of strings; "
         f"received {type(value).__name__}."

--- a/tests/bdd/steps/test_publish_steps.py
+++ b/tests/bdd/steps/test_publish_steps.py
@@ -58,6 +58,19 @@ class _PreflightStubConfig:
     recorder: _PreflightInvocationRecorder | None = None
 
 
+def _create_stub_config(
+    cmd_mox: CmdMox,
+    preflight_overrides: dict[tuple[str, ...], _CommandResponse],
+    preflight_recorder: _PreflightInvocationRecorder,
+) -> _PreflightStubConfig:
+    """Return a stub configuration bound to the shared recorder."""
+    return _PreflightStubConfig(
+        cmd_mox,
+        preflight_overrides,
+        recorder=preflight_recorder,
+    )
+
+
 class _CmdInvocation(typ.Protocol):
     """Protocol describing the cmd-mox invocation payload."""
 
@@ -213,8 +226,10 @@ def when_invoke_lading_publish(
     preflight_recorder: _PreflightInvocationRecorder,
 ) -> dict[str, typ.Any]:
     """Execute the publish CLI via ``python -m`` and capture the result."""
-    stub_config = _PreflightStubConfig(
-        cmd_mox, preflight_overrides, recorder=preflight_recorder
+    stub_config = _create_stub_config(
+        cmd_mox,
+        preflight_overrides,
+        preflight_recorder,
     )
     return _invoke_publish_with_options(repo_root, workspace_directory, stub_config)
 
@@ -231,8 +246,10 @@ def when_invoke_lading_publish_allow_dirty(
     preflight_recorder: _PreflightInvocationRecorder,
 ) -> dict[str, typ.Any]:
     """Execute the publish CLI with ``--allow-dirty`` enabled."""
-    stub_config = _PreflightStubConfig(
-        cmd_mox, preflight_overrides, recorder=preflight_recorder
+    stub_config = _create_stub_config(
+        cmd_mox,
+        preflight_overrides,
+        preflight_recorder,
     )
     return _invoke_publish_with_options(
         repo_root,
@@ -284,6 +301,30 @@ def then_publish_prints_plan(cli_run: dict[str, typ.Any], crate_name: str) -> No
     assert f"- {crate_name} @ 0.1.0" in lines
 
 
+def _get_test_invocations(
+    preflight_recorder: _PreflightInvocationRecorder,
+) -> list[tuple[str, ...]]:
+    """Return recorded cargo test invocations for the current scenario."""
+    test_invocations = preflight_recorder.by_label("cargo::test")
+    if not test_invocations:
+        message = "cargo test pre-flight command was not invoked"
+        raise AssertionError(message)
+    return test_invocations
+
+
+def _find_consecutive_args(
+    invocations: list[tuple[str, ...]],
+    first: str,
+    second: str,
+) -> bool:
+    """Return True when any invocation has ``first`` immediately before ``second``."""
+    for args in invocations:
+        for index in range(len(args) - 1):
+            if args[index] == first and args[index + 1] == second:
+                return True
+    return False
+
+
 @then(
     parsers.parse(
         'the publish command excludes crate "{crate_name}" from pre-flight tests'
@@ -294,18 +335,12 @@ def then_publish_excludes_preflight_crate(
     crate_name: str,
 ) -> None:
     """Assert that cargo test pre-flight invocations skip ``crate_name``."""
-    test_invocations = preflight_recorder.by_label("cargo::test")
-    if not test_invocations:
-        message = "cargo test pre-flight command was not invoked"
+    test_invocations = _get_test_invocations(preflight_recorder)
+    if not _find_consecutive_args(test_invocations, "--exclude", crate_name):
+        message = (
+            f"Expected --exclude {crate_name!r} in cargo test pre-flight invocations"
+        )
         raise AssertionError(message)
-
-    for args in test_invocations:
-        for index, value in enumerate(args[:-1]):
-            if value == "--exclude" and args[index + 1] == crate_name:
-                return
-
-    message = f"Expected --exclude {crate_name!r} in cargo test pre-flight invocations"
-    raise AssertionError(message)
 
 
 @then("the publish command limits pre-flight tests to libraries and binaries")
@@ -313,18 +348,12 @@ def then_publish_limits_preflight_targets(
     preflight_recorder: _PreflightInvocationRecorder,
 ) -> None:
     """Assert that cargo test pre-flight invocations pass --lib and --bins."""
-    test_invocations = preflight_recorder.by_label("cargo::test")
-    if not test_invocations:
-        message = "cargo test pre-flight command was not invoked"
+    test_invocations = _get_test_invocations(preflight_recorder)
+    if not _find_consecutive_args(test_invocations, "--lib", "--bins"):
+        message = (
+            "Expected --lib followed by --bins in cargo test pre-flight invocations"
+        )
         raise AssertionError(message)
-
-    for args in test_invocations:
-        for index, value in enumerate(args[:-1]):
-            if value == "--lib" and args[index + 1] == "--bins":
-                return
-
-    message = "Expected --lib followed by --bins in cargo test pre-flight invocations"
-    raise AssertionError(message)
 
 
 @then(parsers.parse('the publish command lists crates in order "{crate_names}"'))

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -61,6 +61,7 @@ def make_config() -> typ.Callable[..., config_module.LadingConfig]:
     def _make_config(
         *,
         preflight_test_exclude: tuple[str, ...] | None = None,
+        preflight_unit_tests_only: bool = False,
         **overrides: object,
     ) -> config_module.LadingConfig:
         publish_table = config_module.PublishConfig(strip_patches="all", **overrides)
@@ -68,6 +69,7 @@ def make_config() -> typ.Callable[..., config_module.LadingConfig]:
             test_exclude=()
             if preflight_test_exclude is None
             else preflight_test_exclude,
+            unit_tests_only=preflight_unit_tests_only,
         )
         return config_module.LadingConfig(
             publish=publish_table,


### PR DESCRIPTION
## Summary
- Refactors preflight test configuration handling and fixtures for better robustness and maintainability.
- Adds TOML document helpers to reliably create/update preflight config (tables and arrays) during tests.
- Centralizes stub configuration creation for publish flow and updates preflight invocation checks to use new utilities.
- Extends unit-test config fixtures to support preflight_unit_tests_only for targeted testing.

## Changes

### Core
- lading/config.py
  - _string_tuple now strips whitespace from strings and ignores empty values.
  - For sequences, validation now returns a tuple of stripped entries, filtering out empties.
  - Overall behavior improves resilience to noisy input (e.g., whitespace-only entries).

### Tests: BDD fixtures and helpers
- tests/bdd/steps/config_fixtures.py
  - Introduces TOML helpers:
    - _load_or_create_toml_document
    - _ensure_table_exists
    - _ensure_array_field_exists
    - _append_if_absent
  - Refactors preflight test exclusion setup to use the new helpers, ensuring deterministic and clean TOML config generation.
  - Simplifies and hardens creation of preflight.test_exclude lists by appending without duplicates.

### Tests: Publish flow helpers
- tests/bdd/steps/test_publish_steps.py
  - Adds _create_stub_config helper to construct _PreflightStubConfig bound to the shared recorder.
  - Replaces direct _PreflightStubConfig construction with _create_stub_config in publish invocations (both normal and with --allow-dirty).
  - Introduces utilities to inspect recorded cargo test invocations:
    - _get_test_invocations
    - _find_consecutive_args
  - Refactors assertions to use the new helpers for checking cargo test preflight invocations contain expected flags (e.g., --exclude, --lib, --bins).

### Tests: Unit test config fixture
- tests/unit/conftest.py
  - Extend LadingConfig factory with preflight_unit_tests_only flag (default False) and propagate to config.

### Tests: Unit preflight checks
- tests/unit/publish/test_preflight_checks.py
  - Adds _run_and_record_cargo_preflight helper to run cargo preflight and capture the command.
  - Updates tests to use the helper and validates:
    - test_excludes influence on the cargo test command via --exclude
    - unit_tests_only correctly narrows targets to lib and bins via --lib/--bins

## Rationale
- Improves robustness and determinism when manipulating TOML-based config in tests.
- Centralizes and clarifies the creation of stub configurations for publish workflows.
- Provides clearer, reusable test helpers for inspecting cargo preflight invocations, reducing duplicated logic in tests.
- Adds targeted testing capability for preflight unit tests via preflight_unit_tests_only flag.

## Test plan
- Run the full test suite:
  - pytest -q
- Focused verification:
  - pytest tests/unit/publish/test_preflight_checks.py
  - pytest tests/bdd/steps/test_publish_steps.py
  - pytest tests/bdd/steps/config_fixtures.py
- Ensure that preflight exclusions, and lib/bins targeting behave as expected when unit_tests_only is toggled.

## Breaking changes
- Internal behavior of string tuple normalization is stricter (whitespace trimmed, empties dropped). This is an internal improvement and should be transparent to users, but may affect edge-config parsing paths if external code relied on preserving empty strings.
- Tests’ internal configurations and helpers were refactored for robustness; public API remains unchanged.

## Documentation
- No user-facing docs updated in this change. Internal test infrastructure and configuration handling are enhanced for reliability and maintainability.

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/111f172f-e8c7-4e3f-b1d8-278f0199b5cc

## Summary by Sourcery

Refactor preflight test configuration handling and test fixtures for greater robustness and maintainability by normalizing config parsing, introducing reusable TOML and command‐invocation helpers, centralizing stub config creation, and adding support for the new unit_tests_only flag.

Enhancements:
- Strip whitespace and drop empty entries in _string_tuple for more resilient sequence validation.
- Introduce TOML document helpers (_load_or_create_toml_document, _ensure_table_exists, _ensure_array_field_exists, _append_if_absent) for deterministic test config updates.
- Centralize stub publish configurations with a _create_stub_config helper.
- Add Cargo test invocation inspectors (_get_test_invocations, _find_consecutive_args, _run_and_record_cargo_preflight) for cleaner assertion logic.
- Extend the LadingConfig factory to include a preflight_unit_tests_only flag for targeted testing.

Tests:
- Refactor BDD fixtures and publish step tests to leverage TOML helpers, stub config creation, and invocation utilities.
- Update unit preflight tests to use the run-and-record helper and validate --exclude and unit_tests_only behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Configuration string values are now trimmed of leading/trailing whitespace, with empty results normalized consistently across single and multiple value inputs.

* **Tests**
  * Improved test infrastructure for preflight checks with enhanced test configuration options and refactored assertion helpers for better maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->