### PR TITLE
Plan design document and roadmap update for Cuprum migration

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -332,7 +332,7 @@ ______________________________________________________________________
 
 ### **Step 5.3: Test Helper Migration**
 
-**Description:** Update end-to-end test helpers to use cuprum for git operations.
+**Description:** Update end-to-end (e2e) test helpers to use cuprum for git operations.
 
 **Tasks:**
 


### PR DESCRIPTION
## Summary
This pull request updates design and roadmap documentation to reflect the planned migration to Cuprum for command execution (Phase 5). It outlines the migration rationale, scope, catalogue-based approach, compatibility considerations, streaming output strategy, and related documentation and test-helper updates. Roadmap and scripting standards are aligned to guide and standardize the Cuprum-based workflow.

## Changes
- docs/lading-design.md
  - Adds a new “7. Command Execution Migration (Phase 5)” section detailing:
    - Rationale for adopting Cuprum (security-by-default, unified API, observability, pipelines, and typed command building).
    - Migration scope covering four locations:
      1) lading/workspace/metadata.py
      2) lading/utils/path.py
      3) lading/commands/publish_execution.py
      4) tests/e2e/helpers/git_helpers.py
    - Catalogue definition and usage example with a new lading/utils/commands.py module registering allowed programs.
    - Compatibility considerations with cmd-mox and how streaming output can be migrated.
- docs/roadmap.md
  - Introduces Phase 5: Command Execution Modernisation with Step 5.1 to 5.4, detailing core infrastructure, publish execution migration, test helper migration, and documentation/dependency cleanup:
    - 5.1 Core Infrastructure Migration (define the Lading Catalogue, migrate workspace metadata and path utilities).
    - 5.2 Publish Execution Migration (evaluate streaming, migrate _invoke_via_subprocess to Cuprum-based approach).
    - 5.3 Test Helper Migration (update Git helpers to Cuprum usage).
    - 5.4 Documentation and Dependency Cleanup (update scripting standards, remove plumbum, add cuprum).
- docs/scripting-standards.md
  - Replaces references to plumbum with cuprum throughout example snippets and guidance:
    - Introduces Cuprum catalogue-based command execution, scoped within a cuprum catalogue.
    - Demonstrates how to construct commands with sh.make() inside a Catalogue-scoped context.
    - Illustrates output observability hooks and async execution patterns with Cuprum.
    - Updates a reference Cyclopts + cuprum + pathlib example to reflect the new workflow.

## Rationale
- Provide security-first, allowlist-based command execution by default.
- Unify synchronous and asynchronous command execution through Cuprum APIs.
- Improve observability with built-in hooks and events, reducing custom wrappers.
- Align command pipelines with backpressure-like behavior and typed command construction.
- Standardize test and scripting patterns to reduce friction during migration.

## Migration scope
The migration targets four code areas:
- lading/workspace/metadata.py
- lading/utils/path.py
- lading/commands/publish_execution.py
- tests/e2e/helpers/git_helpers.py
In addition, a new module lading/utils/commands.py will host the catalogue definition for allowed executables.

## Catalogue and usage (documentation guidance)
- Define a cuprum Catalogue using Catalogue.from_programs(...), registering all required programs (e.g., cargo, git).
- Use a scoped context (sh.scoped(CATALOGUE)) to construct and run commands via cuprum’s sh.make(...).
- Replace previous plumbum/local-based command construction with cuprum-based patterns, ensuring non-registered commands raise UnknownProgramError.

## Compatibility and testing considerations
- cmd-mox integration should be preserved; ensure IPC passthrough continues to function with cuprum-based invocations.
- For streaming output migration (publish_execution), assess cuprum’s native streaming capabilities or plan for a thin wrapper that preserves real-time output.
- Update end-to-end test helpers (git helpers, etc.) to use cuprum catalogue-based commands.

## Documentation and dependency changes
- Replace plumbum references with cuprum in scripting standards and reference scripts.
- Remove plumbum from dependencies; add cuprum with appropriate version constraint.
- Ensure Cyclopts-related examples reflect Cuprum usage consistently.

## Testing plan (high level)
- Validate that the documentation sections accurately describe the intended Cuprum migration steps.
- Ensure examples in docs compile and demonstrate cuprum usage flow.
- Review cross-references to cmd-mox and ensure guidance remains coherent with the test isolation strategy.

## Review guidance
- Verify that Phases 5.1–5.4 are comprehensively described and align with the codebase’s intended migration trajectory.
- Check that the catalogue-based approach is clearly explained, including how to register programs and scope invocations.
- Confirm that scripting standards reflect cuprum-based command execution consistently across examples.
- Ensure there are no remaining references to plumbum in the updated docs and that cuprum usage is coherent throughout.


🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/9ff3eece-c954-4683-9d4f-be3eb56a612b

## Summary by Sourcery

Update documentation to standardize on cuprum for command execution and define the roadmap and design for migrating from plumbum and subprocess to cuprum across the project.

Documentation:
- Revise scripting standards to replace plumbum with cuprum, including new examples for catalogue-based, typed command execution, observability hooks, async usage, and cmd-mox integration.
- Add a new roadmap phase describing the multi-step migration from plumbum/subprocess to cuprum, covering core infrastructure, publish execution, test helpers, and dependency updates.
- Extend the lading design document with a new section detailing the rationale, scope, catalogue design, cmd-mox compatibility, and streaming output strategy for the cuprum migration.