### PR TITLE
Import episodic lint gates

### DIFF
--- a/.rules/python-exception-design-raising-handling-and-logging.md
+++ b/.rules/python-exception-design-raising-handling-and-logging.md
@@ -1,4 +1,4 @@
-# Python exception design, raising, handling, and logging — Ruff TRY/BLE/EM/LOG, N818, PERF203
+# Python exception design, raising, handling, and logging
 
 This guide distils the intent behind Ruff’s Tryceratops (TRY), Blind Except
 (BLE), flake8‑errmsg (EM), flake8‑logging (LOG), pep8‑naming N818, and Perflint
@@ -56,7 +56,9 @@ When transforming low‑level failures into domain errors, `raise … from …`
 retains traceback lineage (TRY201). Avoid discarding causes in contexts
 expected to preserve them (TRY200).
 
-## 3) Catch narrowly; avoid blind handlers (BLE001), and use `else` for the happy path (TRY300)
+## 3) Catch narrowly; avoid blind handlers (BLE001)
+
+Use `else` for the happy path (TRY300).
 
 ### Avoid blind `except`
 
@@ -93,7 +95,9 @@ def reciprocal(n: float) -> float:
 `else` emphasises the happy path and avoids odd control‑flow within `try`
 blocks.
 
-## 4) Message construction for raises (EM101/EM102) and logging practice (LOG004/LOG007/LOG009/LOG014/LOG015, TRY401)
+## 4) Message construction for raises and logs
+
+This covers EM101/EM102, LOG004/LOG007/LOG009/LOG014/LOG015, and TRY401.
 
 ### Exception messages: construct once, pass once
 
@@ -133,7 +137,8 @@ logger.error("Task %s crashed", task_id)
 try:
     risky()
 except ValueError:
-    logger.exception("Risky operation failed")  # ✅ includes traceback; no %s with exc
+    # Includes traceback; no `%s` with the exception object.
+    logger.exception("Risky operation failed")
 ```
 
 `logger.exception` records the active exception and traceback; appending the

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ MDLINT ?= $(shell which markdownlint)
 NIXIE ?= $(shell which nixie)
 MDFORMAT_ALL ?= $(shell which mdformat-all)
 UV ?= $(shell command -v uv 2>/dev/null || printf '%s/.local/bin/uv' "$$HOME")
-TOOLS = $(MDFORMAT_ALL) ruff ty $(MDLINT) $(NIXIE) uv
+TOOLS = $(MDFORMAT_ALL) ruff ty $(MDLINT) $(NIXIE) $(UV)
 PY_SOURCES := $(sort $(shell find lading scripts -type f -name '*.py' -print))
 VENV_TOOLS = pytest
 PYLINT_PYTHON ?= pypy
@@ -68,7 +68,7 @@ check-fmt: ruff ## Verify formatting
 	ruff format --check
 	# mdformat-all doesn't currently do checking
 
-lint: ruff uv ## Run linters
+lint: ruff $(UV) ## Run linters
 	ruff check
 	$(PYLINT) $(PYLINT_TARGETS)
 

--- a/Makefile
+++ b/Makefile
@@ -18,14 +18,14 @@ PYLINT = $(UV) tool run --python $(PYLINT_PYTHON) --from '$(PYLINT_PYPY_SHIM)' p
 
 all: check-fmt lint test typecheck
 
-.venv: pyproject.toml
-	uv venv --clear
+.venv: pyproject.toml $(UV)
+	$(UV) venv --clear
 
-build: uv .venv ## Build virtual-env and install deps
-	uv sync --group dev
+build: $(UV) .venv ## Build virtual-env and install deps
+	$(UV) sync --group dev
 
 build-release: build ## Build artefacts (sdist & wheel)
-	uv run python -m build --sdist --wheel
+	$(UV) run python -m build --sdist --wheel
 
 clean: ## Remove build artifacts
 	rm -rf build dist *.egg-info \
@@ -41,7 +41,7 @@ define ensure_tool
 endef
 
 define ensure_tool_venv
-	@uv run which $(1) >/dev/null 2>&1 || { \
+	@$(UV) run which $(1) >/dev/null 2>&1 || { \
 	  printf "Error: '%s' is required in the virtualenv, but is not installed\n" "$(1)" >&2; \
 	  exit 1; \
 	}
@@ -82,8 +82,8 @@ markdownlint: $(MDLINT) ## Lint Markdown files
 nixie: $(NIXIE) ## Validate Mermaid diagrams
 	nixie --no-sandbox
 
-test: build uv pytest ## Run tests
-	uv run pytest -v
+test: build $(UV) pytest ## Run tests
+	$(UV) run pytest -v
 
 help: ## Show available targets
 	@grep -E '^[a-zA-Z_-]+:.*?##' $(MAKEFILE_LIST) | \

--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,15 @@
 MDLINT ?= $(shell which markdownlint)
 NIXIE ?= $(shell which nixie)
 MDFORMAT_ALL ?= $(shell which mdformat-all)
+UV ?= $(shell command -v uv 2>/dev/null || printf '%s/.local/bin/uv' "$$HOME")
 TOOLS = $(MDFORMAT_ALL) ruff ty $(MDLINT) $(NIXIE) uv
 PY_SOURCES := $(sort $(shell find lading scripts -type f -name '*.py' -print))
 VENV_TOOLS = pytest
+PYLINT_PYTHON ?= pypy
+PYLINT_TARGETS ?= lading scripts tests
+PYLINT_PYPY_SHIM_REF ?= 726d09f968b4d729ee4b29c71fc732e744854f3b
+PYLINT_PYPY_SHIM = git+https://github.com/leynos/pylint-pypy-shim.git@$(PYLINT_PYPY_SHIM_REF)
+PYLINT = $(UV) tool run --python $(PYLINT_PYTHON) --from '$(PYLINT_PYPY_SHIM)' pylint-pypy
 
 .PHONY: help all clean build build-release lint fmt check-fmt \
 	markdownlint nixie test typecheck $(TOOLS) $(VENV_TOOLS)
@@ -64,6 +70,7 @@ check-fmt: ruff ## Verify formatting
 
 lint: ruff ## Run linters
 	ruff check
+	$(PYLINT) $(PYLINT_TARGETS)
 
 typecheck: build ty ## Run typechecking
 	ty check --python-version 3.13 $(PY_SOURCES)

--- a/Makefile
+++ b/Makefile
@@ -68,7 +68,7 @@ check-fmt: ruff ## Verify formatting
 	ruff format --check
 	# mdformat-all doesn't currently do checking
 
-lint: ruff ## Run linters
+lint: ruff uv ## Run linters
 	ruff check
 	$(PYLINT) $(PYLINT_TARGETS)
 

--- a/docs/cmd-mox-usage-guide.md
+++ b/docs/cmd-mox-usage-guide.md
@@ -73,7 +73,7 @@ A typical test brings the three phases together:
 cmd_mox.mock("git").with_args("clone", "repo").returns(exit_code=0)
 
 my_tool.clone_repo("repo")
-# Replay begins automatically before the test function executes; verification runs during teardown.
+# Replay begins before the test executes; verification runs during teardown.
 ```
 
 ## Stubs, mocks and spies

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -13,6 +13,46 @@ implementation module may be invoked directly:
 uv run python -m lading.cli --help
 ```
 
+## Linting workflow
+
+Run the Python lint gate with:
+
+```bash
+make lint
+```
+
+The target is deliberately two-tiered. Ruff runs first because it is fast,
+handles broad style and correctness checks, and imports the stricter lint policy
+used by `leynos/episodic`. If Ruff passes, the target then runs Pylint through
+the pinned `pylint-pypy-shim` tool under PyPy. This second tier is focused on
+rule families that complement Ruff, especially logging format safety, pattern
+matching checks, selected simplification checks, deprecated standard-library
+usage, file hygiene, and design-size limits.
+
+The relevant Makefile variables are:
+
+- `PYLINT_PYTHON` — Python executable used by `uv tool run`; defaults to `pypy`.
+- `PYLINT_TARGETS` — directories passed to Pylint; defaults to `lading scripts
+  tests`.
+- `PYLINT_PYPY_SHIM_REF` — pinned `pylint-pypy-shim` revision.
+- `PYLINT_PYPY_SHIM` — Git URL assembled from the pinned shim revision.
+- `PYLINT` — full `uv tool run --python $(PYLINT_PYTHON)` invocation for the
+  shimmed Pylint command.
+
+The `lint` target depends on both `ruff` and `uv`, so it fails during tool
+checks if either command is unavailable. Keep any future lint additions wired
+through Makefile prerequisites as well as command invocations so local failures
+remain early and clear.
+
+Ruff and Pylint policy live in `pyproject.toml`. The Ruff configuration enables
+preview rules, targets Python 3.13, imports the selected `episodic` rule set,
+and bans deprecated `typing` aliases in favour of built-in collection types,
+`collections.abc`, `collections`, `contextlib`, or `re` as appropriate. The
+Pylint configuration keeps the pass opt-in by disabling all messages first and
+then enabling only the chosen second-tier checks. Local ignores and thresholds
+document existing codebase constraints that should be addressed as focused
+cleanup work rather than incidental lint-gate churn.
+
 ## Testing hooks
 
 Behavioural tests invoke the CLI as an external process and spy on the `python`

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -41,7 +41,7 @@ The relevant Makefile variables are:
 
 The `lint` target depends on both `ruff` and `uv`, so it fails during tool
 checks if either command is unavailable. Keep any future lint additions wired
-through Makefile prerequisites as well as command invocations so local failures
+through Makefile prerequisites as well as command invocations, so local failures
 remain early and clear.
 
 Ruff and Pylint policy live in `pyproject.toml`. The Ruff configuration enables

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -13,6 +13,22 @@ implementation module may be invoked directly:
 uv run python -m lading.cli --help
 ```
 
+## Build environment
+
+The Makefile resolves the `uv` executable through the `UV` variable:
+
+```make
+UV ?= $(shell command -v uv 2>/dev/null || printf '%s/.local/bin/uv' "$$HOME")
+```
+
+When `uv` is available on `PATH`, `command -v uv` supplies the executable path.
+If it is not on `PATH`, the Makefile falls back to `$HOME/.local/bin/uv`, which
+matches the default user-local installation path used by the project
+environment. Targets that create the virtual environment, sync dependencies,
+run builds, or execute tests should depend on and invoke `$(UV)` rather than a
+literal `uv` command, so Makefile validation and command execution use the same
+resolved executable.
+
 ## Linting workflow
 
 Run the Python lint gate with:
@@ -22,12 +38,12 @@ make lint
 ```
 
 The target is deliberately two-tiered. Ruff runs first because it is fast,
-handles broad style and correctness checks, and imports the stricter lint policy
-used by `leynos/episodic`. If Ruff passes, the target then runs Pylint through
-the pinned `pylint-pypy-shim` tool under PyPy. This second tier is focused on
-rule families that complement Ruff, especially logging format safety, pattern
-matching checks, selected simplification checks, deprecated standard-library
-usage, file hygiene, and design-size limits.
+handles broad style and correctness checks, and imports the stricter lint
+policy used by `leynos/episodic`. If Ruff passes, the target then runs Pylint
+through the pinned `pylint-pypy-shim` tool under PyPy. This second tier is
+focused on rule families that complement Ruff, especially logging format
+safety, pattern matching checks, selected simplification checks, deprecated
+standard-library usage, file hygiene, and design-size limits.
 
 The relevant Makefile variables are:
 
@@ -41,8 +57,8 @@ The relevant Makefile variables are:
 
 The `lint` target depends on both `ruff` and `uv`, so it fails during tool
 checks if either command is unavailable. Keep any future lint additions wired
-through Makefile prerequisites as well as command invocations, so local failures
-remain early and clear.
+through Makefile prerequisites as well as command invocations, so local
+failures remain early and clear.
 
 Ruff and Pylint policy live in `pyproject.toml`. The Ruff configuration enables
 preview rules, targets Python 3.13, imports the selected `episodic` rule set,

--- a/docs/lading-design.md
+++ b/docs/lading-design.md
@@ -192,7 +192,7 @@ and live modes, and feeds the resulting plan to execution helpers.
 
 ```mermaid
 graph TD
-    A["User CLI command: lading publish"] --> B["Module: lading.commands.publish (publish.py)"]
+    A["CLI: lading publish"] --> B["Module: lading.commands.publish"]
     B --> C["Module: lading.commands.publish_plan (publish_plan.py)"]
     C --> C1["Build PublishPlan with publishable_names"]
     B --> D["Module: lading.commands.publish_manifest (publish_manifest.py)"]
@@ -210,7 +210,7 @@ graph TD
     J --> L["should_use_cmd_mox_stub"]
     J --> M["normalise_cmd_mox_command"]
 
-    B --> N["Use re-exported helpers: append_section, format_plan, split_command, should_use_cmd_mox_stub, normalise_cmd_mox_command"]
+    B --> N["Use re-exported publish helpers"]
     N --> O["Compose final publish plan and execute commands"]
 ```
 
@@ -494,13 +494,13 @@ sequenceDiagram
     Caller->>publish.py: publish(…, forbid_dirty=…)
     publish.py->>publish.py: _build_preflight_environment(config.preflight)
     alt aux_build configured
-        publish.py->>publish_execution: _run_aux_build_commands(workspace_root, commands, runner, env)
+        publish.py->>publish_execution: _run_aux_build_commands(...)
         publish_execution-->>publish.py: (rc, stdout, stderr)
     end
-    publish.py->>publish_execution: _invoke(cargo test --lib, cwd=workspace_root, env=env)
+    publish.py->>publish_execution: _invoke(cargo test --lib, ...)
     publish_execution-->>publish.py: (rc, stdout, stderr)
     alt rc != 0
-        publish.py->>publish_diagnostics: _append_compiletest_diagnostics(message, stdout, stderr, tail_lines)
+        publish.py->>publish_diagnostics: _append_compiletest_diagnostics(...)
         publish_diagnostics-->>publish.py: augmented_message
         publish.py-->>Caller: PublishPreflightError(augmented_message)
     else rc == 0
@@ -730,7 +730,12 @@ layer routes commands through cmd-mox IPC rather than spawning real processes:
 from cuprum import scoped, sh
 from lading.utils.commands import CARGO, GIT, LADING_CATALOGUE
 
-def _invoke(program: Program, args: tuple[str, ...], *, cwd: Path | None = None) -> CommandResult:
+def _invoke(
+    program: Program,
+    args: tuple[str, ...],
+    *,
+    cwd: Path | None = None,
+) -> CommandResult:
     """Execute command, routing through cmd-mox when stub mode is enabled."""
     if _should_use_cmd_mox_stub():
         # Route to cmd-mox IPC server for test isolation

--- a/docs/scripting-standards.md
+++ b/docs/scripting-standards.md
@@ -75,7 +75,10 @@ def default(
 
     # Lists (whitespace/newline separated by default)
     formats: list[str] | None = None,
-    man_paths: Annotated[list[Path] | None, Parameter(env_var="INPUT_MAN_PATHS")] = None,
+    man_paths: Annotated[
+        list[Path] | None,
+        Parameter(env_var="INPUT_MAN_PATHS"),
+    ] = None,
     deb_depends: list[str] | None = None,
     rpm_depends: list[str] | None = None,
 ):
@@ -127,7 +130,10 @@ Guidance:
 - Per‑parameter environment names can be pinned for backwards compatibility:
 
   ```python
-  config_out: Annotated[Optional[Path], Parameter(env_var="INPUT_CONFIG_PATH")] = None
+  config_out: Annotated[
+      Optional[Path],
+      Parameter(env_var="INPUT_CONFIG_PATH"),
+  ] = None
   ```
 
 ## cuprum: typed command execution
@@ -305,7 +311,12 @@ f.write_text("1.2.3\n", encoding="utf-8")
 version = f.read_text(encoding="utf-8").strip()
 
 # Atomic write pattern (tmp → replace)
-with tempfile.NamedTemporaryFile("w", delete=False, dir=f.parent, encoding="utf-8") as tmp:
+with tempfile.NamedTemporaryFile(
+    "w",
+    delete=False,
+    dir=f.parent,
+    encoding="utf-8",
+) as tmp:
     tmp.write("new-contents\n")
     tmp_path = Path(tmp.name)
 

--- a/docs/users-guide.md
+++ b/docs/users-guide.md
@@ -119,41 +119,47 @@ strip_patches = "per-crate" # "all" | "per-crate" | false
 test_exclude = ["slow-integration-suite"]
 unit_tests_only = false
 aux_build = [["cargo", "+nightly", "test", "-p", "lint", "--no-run"]]
-compiletest_extern = { ui_test_helpers = "target/debug/deps/libui_test_helpers.so" }
+compiletest_extern = {
+  ui_test_helpers = "target/debug/deps/libui_test_helpers.so"
+}
 env = { DYLINT_LOCALE = "en_GB" }
 stderr_tail_lines = 40
 ```
 
 ### `[bump]`
 
-| Key       | Type             | Default | Meaning                                       |
-| --------- | ---------------- | ------- | --------------------------------------------- |
-| `exclude` | array of strings | `[]`    | Crate names to exclude from manifest updates. |
+- `exclude`: array of strings, default `[]`. Crate names to exclude from
+  manifest updates.
 
 ### `[bump.documentation]`
 
-| Key     | Type             | Default | Meaning                                                                    |
-| ------- | ---------------- | ------- | -------------------------------------------------------------------------- |
-| `globs` | array of strings | `[]`    | Glob patterns for Markdown files whose TOML code fences should be updated. |
+- `globs`: array of strings, default `[]`. Glob patterns for Markdown files
+  whose TOML code fences should be updated.
 
 ### `[publish]`
 
-| Key             | Type                                   | Default       | Meaning                                                                     |
-| --------------- | -------------------------------------- | ------------- | --------------------------------------------------------------------------- |
-| `exclude`       | array of strings                       | `[]`          | Crate names to exclude from publication.                                    |
-| `order`         | array of strings                       | `[]`          | Explicit publish order; overrides dependency-derived ordering when present. |
-| `strip_patches` | one of `"all"`, `"per-crate"`, `false` | `"per-crate"` | How to edit `[patch.crates-io]` in the staged workspace before packaging.   |
+- `exclude`: array of strings, default `[]`. Crate names to exclude from
+  publication.
+- `order`: array of strings, default `[]`. Explicit publish order; overrides
+  dependency-derived ordering when present.
+- `strip_patches`: one of `"all"`, `"per-crate"`, or `false`; default
+  `"per-crate"`. Controls how `[patch.crates-io]` is edited in the staged
+  workspace before packaging.
 
 ### `[preflight]`
 
-| Key                  | Type                      | Default | Meaning                                                                         |
-| -------------------- | ------------------------- | ------- | ------------------------------------------------------------------------------- |
-| `test_exclude`       | array of strings          | `[]`    | Crate names to exclude from `cargo test` by passing `--exclude`.                |
-| `unit_tests_only`    | boolean                   | `false` | Append `--lib --bins` to the pre-flight `cargo test` invocation.                |
-| `aux_build`          | nested array of strings   | `[]`    | Extra commands (tokenized) to run before cargo pre-flight checks.               |
-| `compiletest_extern` | table (string → string)   | `{}`    | Extra `--extern` entries to append to `RUSTFLAGS` for compiletest-style suites. |
-| `env`                | table (string → string)   | `{}`    | Environment overrides applied to git/cargo invocations run by `publish`.        |
-| `stderr_tail_lines`  | integer (≥ 0)             | `40`    | Number of lines to tail from referenced `*.stderr` files when tests fail.       |
+- `test_exclude`: array of strings, default `[]`. Crate names to exclude from
+  `cargo test` by passing `--exclude`.
+- `unit_tests_only`: boolean, default `false`. Append `--lib --bins` to the
+  pre-flight `cargo test` invocation.
+- `aux_build`: nested array of strings, default `[]`. Extra tokenized commands
+  to run before cargo pre-flight checks.
+- `compiletest_extern`: table of string keys and values, default `{}`. Extra
+  `--extern` entries to append to `RUSTFLAGS` for compiletest-style suites.
+- `env`: table of string keys and values, default `{}`. Environment overrides
+  applied to git/cargo invocations run by `publish`.
+- `stderr_tail_lines`: integer greater than or equal to zero, default `40`.
+  Number of lines to tail from referenced `*.stderr` files when tests fail.
 
 ## Reference: CLI flags and environment variables
 

--- a/lading/cli.py
+++ b/lading/cli.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import collections.abc as cabc
 import logging
 import os
 import re
@@ -72,7 +73,7 @@ def _validate_workspace_value(value: str) -> str:
     return value
 
 
-def _parse_workspace_flag(tokens: typ.Sequence[str], index: int) -> tuple[str, int]:
+def _parse_workspace_flag(tokens: cabc.Sequence[str], index: int) -> tuple[str, int]:
     """Parse ``--workspace-root <path>`` form starting at ``index``."""
     try:
         candidate = tokens[index + 1]
@@ -90,7 +91,7 @@ def _parse_workspace_equals(argument: str, index: int) -> tuple[str, int]:
 
 
 def _extract_workspace_override(
-    tokens: typ.Sequence[str],
+    tokens: cabc.Sequence[str],
 ) -> tuple[str | None, list[str]]:
     """Split ``--workspace-root`` from CLI tokens.
 
@@ -158,7 +159,7 @@ def _configure_logging(stream: typ.TextIO | None = None) -> None:
 
 
 @contextmanager
-def _workspace_env(value: Path) -> typ.Iterator[None]:
+def _workspace_env(value: Path) -> cabc.Iterator[None]:
     """Temporarily set :data:`WORKSPACE_ROOT_ENV_VAR` to ``value``."""
     previous = os.environ.get(WORKSPACE_ROOT_ENV_VAR)
     os.environ[WORKSPACE_ROOT_ENV_VAR] = str(value)
@@ -171,7 +172,7 @@ def _workspace_env(value: Path) -> typ.Iterator[None]:
             os.environ[WORKSPACE_ROOT_ENV_VAR] = previous
 
 
-def _dispatch_and_print(tokens: typ.Sequence[str]) -> int:
+def _dispatch_and_print(tokens: cabc.Sequence[str]) -> int:
     """Execute the Cyclopts app and print command results."""
     try:
         result = app(tokens)
@@ -190,7 +191,7 @@ def _dispatch_and_print(tokens: typ.Sequence[str]) -> int:
     return 0
 
 
-def main(argv: typ.Sequence[str] | None = None) -> int:
+def main(argv: cabc.Sequence[str] | None = None) -> int:
     """Entry point for ``python -m lading.cli``."""
     try:
         if argv is None:
@@ -231,7 +232,7 @@ def main(argv: typ.Sequence[str] | None = None) -> int:
 
 def _run_with_context(
     workspace_root: Path,
-    runner: typ.Callable[
+    runner: cabc.Callable[
         [Path, config.LadingConfig | None, WorkspaceGraph | None],
         str,
     ],

--- a/lading/commands/bump.py
+++ b/lading/commands/bump.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import collections.abc as cabc
 import dataclasses as dc
 import types
 import typing as typ
@@ -38,7 +39,7 @@ class BumpOptions:
     dry_run: bool = False
     configuration: LadingConfig | None = None
     workspace: WorkspaceGraph | None = None
-    dependency_sections: typ.Mapping[str, typ.Collection[str]] = dc.field(
+    dependency_sections: cabc.Mapping[str, cabc.Collection[str]] = dc.field(
         default_factory=lambda: types.MappingProxyType({})
     )
     include_workspace_sections: bool = False
@@ -48,8 +49,8 @@ class BumpOptions:
 class BumpChanges:
     """Collection of files altered by a bump run."""
 
-    manifests: typ.Sequence[Path] = ()
-    documents: typ.Sequence[Path] = ()
+    manifests: cabc.Sequence[Path] = ()
+    documents: cabc.Sequence[Path] = ()
 
 
 @dc.dataclass(frozen=True, slots=True)
@@ -284,10 +285,12 @@ def _format_manifest_path(manifest_path: Path, workspace_root: Path) -> str:
 def _validate_bump_options(options: BumpOptions) -> tuple[LadingConfig, WorkspaceGraph]:
     """Validate and extract required configuration and workspace from options.
 
-    Raises:
+    Raises
+    ------
         ValueError: If configuration or workspace is None.
 
-    Returns:
+    Returns
+    -------
         Tuple of (configuration, workspace).
 
     """
@@ -299,7 +302,7 @@ def _validate_bump_options(options: BumpOptions) -> tuple[LadingConfig, Workspac
 
 def _determine_package_selectors(
     crate_name: str,
-    excluded: typ.Collection[str],
+    excluded: cabc.Collection[str],
 ) -> tuple[tuple[str, ...], ...]:
     """Return package selectors for the crate, respecting exclusion rules.
 
@@ -307,7 +310,8 @@ def _determine_package_selectors(
         crate_name: Name of the crate to check.
         excluded: Collection of excluded crate names.
 
-    Returns:
+    Returns
+    -------
         Package selectors tuple, or empty tuple if crate is excluded.
 
     """
@@ -316,11 +320,12 @@ def _determine_package_selectors(
 
 def _should_skip_crate_update(
     selectors: tuple[tuple[str, ...], ...],
-    dependency_sections: typ.Mapping[str, typ.Collection[str]],
+    dependency_sections: cabc.Mapping[str, cabc.Collection[str]],
 ) -> bool:
     """Check if a crate update should be skipped due to no work required.
 
-    Returns:
+    Returns
+    -------
         True if both selectors and dependency_sections are empty.
 
     """
@@ -328,8 +333,8 @@ def _should_skip_crate_update(
 
 
 def _freeze_dependency_sections(
-    sections: typ.Mapping[str, typ.Collection[str]],
-) -> typ.Mapping[str, typ.Collection[str]]:
+    sections: cabc.Mapping[str, cabc.Collection[str]],
+) -> cabc.Mapping[str, cabc.Collection[str]]:
     """Return an immutable mapping for dependency sections."""
     if not sections:
         return types.MappingProxyType({})
@@ -352,7 +357,8 @@ def _update_manifest(
         options: Bump options controlling dry-run, dependency sections, and
             whether to include workspace-level dependency sections.
 
-    Returns:
+    Returns
+    -------
         True if any changes were made.
 
     """
@@ -374,7 +380,7 @@ def _update_manifest(
 
 
 def _workspace_dependency_sections(
-    updated_crates: typ.Collection[str],
+    updated_crates: cabc.Collection[str],
 ) -> dict[str, set[str]]:
     """Return dependency names to update for the workspace manifest."""
     crate_names = {name for name in updated_crates if name}
@@ -389,7 +395,7 @@ def _workspace_dependency_sections(
 
 def _dependency_sections_for_crate(
     crate: WorkspaceCrate,
-    updated_crates: typ.Collection[str],
+    updated_crates: cabc.Collection[str],
 ) -> dict[str, set[str]]:
     """Return dependency names grouped by section for ``crate``."""
     if not crate.dependencies:

--- a/lading/commands/bump_docs.py
+++ b/lading/commands/bump_docs.py
@@ -31,6 +31,7 @@ Examples
 
 from __future__ import annotations
 
+import collections.abc as cabc
 import logging
 import re
 import typing as typ
@@ -86,9 +87,9 @@ def resolve_documentation_targets(
 
 
 def update_documentation_files(
-    documentation_paths: typ.Iterable[Path],
+    documentation_paths: cabc.Iterable[Path],
     target_version: str,
-    updated_crates: typ.Collection[str],
+    updated_crates: cabc.Collection[str],
     *,
     dry_run: bool,
 ) -> set[Path]:
@@ -132,7 +133,7 @@ def update_documentation_files(
 
 def rewrite_markdown_toml_fences(
     markdown_text: str,
-    dependency_targets: typ.Collection[str],
+    dependency_targets: cabc.Collection[str],
     target_version: str,
 ) -> tuple[str, bool]:
     """Rewrite TOML fences for ``dependency_targets`` within Markdown text.
@@ -171,7 +172,7 @@ def rewrite_markdown_toml_fences(
 def replace_markdown_fences(
     markdown_text: str,
     language: str,
-    transform: typ.Callable[[str], str],
+    transform: cabc.Callable[[str], str],
 ) -> str:
     """Replace fenced code blocks of ``language`` with ``transform``.
 
@@ -233,7 +234,7 @@ def render_fence(
     token: Token,
     lines: list[str],
     language: str,
-    transform: typ.Callable[[str], str],
+    transform: cabc.Callable[[str], str],
 ) -> str:
     """Return a rewritten fence for ``token`` using ``transform``.
 
@@ -311,7 +312,7 @@ def _try_assign_version_at_path(
 def _update_single_dependency_section(
     document: TOMLDocument,
     section: str,
-    dependency_targets: typ.Collection[str],
+    dependency_targets: cabc.Collection[str],
     target_version: str,
 ) -> bool:
     """Update a single dependency section if it exists."""
@@ -323,7 +324,7 @@ def _update_single_dependency_section(
 
 def update_toml_snippet_dependencies(
     document: TOMLDocument,
-    dependency_targets: typ.Collection[str],
+    dependency_targets: cabc.Collection[str],
     target_version: str,
 ) -> bool:
     """Update dependency sections in a TOML snippet document.
@@ -357,7 +358,7 @@ def update_toml_snippet_dependencies(
 
 def update_toml_snippet_versions(
     snippet: str,
-    dependency_targets: typ.Collection[str],
+    dependency_targets: cabc.Collection[str],
     target_version: str,
 ) -> tuple[str, bool]:
     """Return a TOML snippet with dependency versions rewritten.

--- a/lading/commands/bump_toml.py
+++ b/lading/commands/bump_toml.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import collections.abc as cabc
 import os
 import re
 import tempfile
@@ -96,7 +97,7 @@ def update_dependency_entry(
 
 def update_dependency_table(
     table: _TableLike,
-    dependency_names: typ.Collection[str],
+    dependency_names: cabc.Collection[str],
     target_version: str,
 ) -> bool:
     """Update dependency requirements within ``table`` for ``dependency_names``."""
@@ -113,7 +114,7 @@ def update_dependency_table(
 def update_section(
     document: TOMLDocument,
     path: tuple[str, ...],
-    names: typ.Collection[str],
+    names: cabc.Collection[str],
     target_version: str,
 ) -> bool:
     """Update dependency versions in the table at ``path``.
@@ -125,7 +126,8 @@ def update_section(
         names: Collection of dependency names to update.
         target_version: The target version to apply.
 
-    Returns:
+    Returns
+    -------
         True if any version entries were changed.
 
     """
@@ -137,7 +139,7 @@ def update_section(
 
 def update_dependency_sections(
     document: TOMLDocument,
-    dependency_sections: typ.Mapping[str, typ.Collection[str]],
+    dependency_sections: cabc.Mapping[str, cabc.Collection[str]],
     target_version: str,
     *,
     include_workspace_sections: bool = False,
@@ -151,7 +153,8 @@ def update_dependency_sections(
         include_workspace_sections: When True, also update entries in
             ``[workspace.<section>]`` tables (e.g., ``[workspace.dependencies]``).
 
-    Returns:
+    Returns
+    -------
         True if any version entries were changed.
 
     """

--- a/lading/commands/publish.py
+++ b/lading/commands/publish.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import atexit
+import collections.abc as cabc
 import dataclasses as dc
 import logging
 import os
@@ -56,10 +57,10 @@ if typ.TYPE_CHECKING:
 class _CargoPreflightOptions:
     """Options controlling how cargo pre-flight commands are invoked."""
 
-    extra_args: typ.Sequence[str]
-    test_excludes: typ.Sequence[str] = ()
+    extra_args: cabc.Sequence[str]
+    test_excludes: cabc.Sequence[str] = ()
     unit_tests_only: bool = False
-    env: typ.Mapping[str, str] | None = None
+    env: cabc.Mapping[str, str] | None = None
     diagnostics_tail_lines: int | None = None
 
 
@@ -143,7 +144,7 @@ def _run_aux_build_commands(
     commands: tuple[tuple[str, ...], ...],
     *,
     runner: _CommandRunner,
-    env: typ.Mapping[str, str] | None,
+    env: cabc.Mapping[str, str] | None,
 ) -> None:
     """Execute auxiliary build commands prior to cargo pre-flight runs."""
     for command in commands:
@@ -168,7 +169,7 @@ def _resolve_extern_path(workspace_root: Path, raw_path: str) -> Path:
 
 
 def _apply_compiletest_externs(
-    env: typ.Mapping[str, str],
+    env: cabc.Mapping[str, str],
     externs: tuple[config_module.CompiletestExtern, ...],
     *,
     workspace_root: Path,
@@ -620,7 +621,7 @@ def _preflight_argument_sets(
     return check_arguments, test_arguments
 
 
-def _normalise_test_excludes(entries: typ.Sequence[str]) -> tuple[str, ...]:
+def _normalise_test_excludes(entries: cabc.Sequence[str]) -> tuple[str, ...]:
     """Return sorted, deduplicated, trimmed crate names for ``--exclude`` flags."""
     return tuple(sorted({crate.strip() for crate in entries if crate.strip()}))
 
@@ -643,7 +644,7 @@ def _verify_clean_working_tree(
     *,
     allow_dirty: bool,
     runner: _CommandRunner,
-    env: typ.Mapping[str, str] | None = None,
+    env: cabc.Mapping[str, str] | None = None,
 ) -> None:
     """Ensure ``workspace_root`` has no uncommitted changes unless allowed."""
     if allow_dirty:

--- a/lading/commands/publish_execution.py
+++ b/lading/commands/publish_execution.py
@@ -15,6 +15,7 @@ command naming before IPC.
 from __future__ import annotations
 
 import codecs
+import collections.abc as cabc
 import dataclasses as dc
 import logging
 import os
@@ -22,7 +23,7 @@ import re
 import subprocess
 import sys
 import threading
-import types  # noqa: TC003 -- module-scope for cmd_runner_module: types.ModuleType | None (NameError guard)
+import types
 import typing as typ
 from pathlib import Path
 
@@ -79,8 +80,8 @@ class _CmdMoxCommandRunner(typ.Protocol):
     def prepare_environment(
         self,
         lookup_path: str,
-        extra_env: typ.Mapping[str, str] | None,
-        invocation_env: typ.Mapping[str, str],
+        extra_env: cabc.Mapping[str, str] | None,
+        invocation_env: cabc.Mapping[str, str],
     ) -> dict[str, str]: ...
 
     def resolve_command_with_override(
@@ -96,16 +97,16 @@ class _CmdMoxPassthroughDirective(typ.Protocol):
 
     invocation_id: str
     lookup_path: str
-    extra_env: typ.Mapping[str, str] | None
+    extra_env: cabc.Mapping[str, str] | None
 
 
 class _CmdMoxInvocation(typ.Protocol):
     """Invocation object passed to cmd-mox and used for passthrough."""
 
     command: str
-    args: typ.Sequence[str]
+    args: cabc.Sequence[str]
     stdin: str
-    env: typ.Mapping[str, str]
+    env: cabc.Mapping[str, str]
 
 
 class _CommandRunner(typ.Protocol):
@@ -113,10 +114,10 @@ class _CommandRunner(typ.Protocol):
 
     def __call__(
         self,
-        command: typ.Sequence[str],
+        command: cabc.Sequence[str],
         *,
         cwd: Path | None = None,
-        env: typ.Mapping[str, str] | None = None,
+        env: cabc.Mapping[str, str] | None = None,
     ) -> tuple[int, str, str]:
         """Execute ``command`` and return exit status and decoded output."""
 
@@ -126,7 +127,7 @@ class _SubprocessContext:
     """Execution context for subprocess invocations."""
 
     cwd: Path | None = None
-    env: typ.Mapping[str, str] | None = None
+    env: cabc.Mapping[str, str] | None = None
     stdin_data: str | None = None
 
 
@@ -138,10 +139,10 @@ def _publish_error(message: str) -> PublishPreflightError:
 
 
 def _invoke(
-    command: typ.Sequence[str],
+    command: cabc.Sequence[str],
     *,
     cwd: Path | None = None,
-    env: typ.Mapping[str, str] | None = None,
+    env: cabc.Mapping[str, str] | None = None,
 ) -> tuple[int, str, str]:
     """Execute ``command`` and return the exit status and decoded streams."""
     log_command_invocation(LOGGER, command, cwd)
@@ -153,7 +154,7 @@ def _invoke(
     return _invoke_via_subprocess(program, args, context)
 
 
-def _split_command(command: typ.Sequence[str]) -> tuple[str, tuple[str, ...]]:
+def _split_command(command: cabc.Sequence[str]) -> tuple[str, tuple[str, ...]]:
     """Return the program and argument tuple for ``command``."""
     if not command:
         message = "Command sequence must contain at least one entry"
@@ -190,7 +191,7 @@ def _prepare_cmd_mox_context() -> tuple[object, object, float]:
 
 
 def _build_cmd_mox_invocation_env(
-    cwd: Path | None, env: typ.Mapping[str, str] | None
+    cwd: Path | None, env: cabc.Mapping[str, str] | None
 ) -> dict[str, str]:
     """Return the environment mapping for cmd-mox invocations."""
     invocation_env = metadata_module._build_invocation_environment(None)
@@ -215,9 +216,9 @@ def _process_cmd_mox_response(
 
 
 def _invoke_via_cmd_mox(
-    command: typ.Sequence[str],
+    command: cabc.Sequence[str],
     cwd: Path | None,
-    env: typ.Mapping[str, str] | None,
+    env: cabc.Mapping[str, str] | None,
 ) -> tuple[int, str, str]:
     """Route ``command`` through the cmd-mox IPC server when enabled."""
     ipc, env_mod, timeout = _prepare_cmd_mox_context()
@@ -309,7 +310,7 @@ def _invoke_via_subprocess(
 
 
 def _normalise_environment(
-    env: typ.Mapping[str, str] | None,
+    env: cabc.Mapping[str, str] | None,
 ) -> dict[str, str] | None:
     """Return ``env`` with stringified values to satisfy ``subprocess``."""
     if env is None:
@@ -483,7 +484,7 @@ def _write_to_sink(sink: typ.TextIO | None, payload: str) -> typ.TextIO | None:
     return sink
 
 
-def _apply_cmd_mox_environment(env: typ.Mapping[str, str] | None) -> None:
+def _apply_cmd_mox_environment(env: cabc.Mapping[str, str] | None) -> None:
     """Merge cmd-mox supplied environment updates into ``os.environ``."""
     if not env:
         return
@@ -505,7 +506,7 @@ def _format_thread_name(program: str, stream: str) -> str:
 
 
 def _log_subprocess_spawn(
-    command: typ.Sequence[str], cwd: Path | None
+    command: cabc.Sequence[str], cwd: Path | None
 ) -> None:  # pragma: no cover - logging only
     rendered = format_command(command)
     if cwd is None:
@@ -514,7 +515,7 @@ def _log_subprocess_spawn(
         LOGGER.info("Spawning subprocess: %s (cwd=%s)", rendered, cwd)
 
 
-def _log_subprocess_environment(env: typ.Mapping[str, str] | None) -> None:
+def _log_subprocess_environment(env: cabc.Mapping[str, str] | None) -> None:
     """Log redacted environment overrides for subprocess execution."""
     if not env:
         LOGGER.debug("Spawning subprocess with inherited environment")
@@ -523,7 +524,7 @@ def _log_subprocess_environment(env: typ.Mapping[str, str] | None) -> None:
     LOGGER.debug("Subprocess environment overrides: %s", redacted)
 
 
-def _redact_environment(env: typ.Mapping[str, str]) -> dict[str, str]:
+def _redact_environment(env: cabc.Mapping[str, str]) -> dict[str, str]:
     """Return ``env`` with sensitive values replaced by placeholders."""
     redacted: dict[str, str] = {}
     for key, value in env.items():

--- a/lading/commands/publish_execution.py
+++ b/lading/commands/publish_execution.py
@@ -267,7 +267,9 @@ def _invoke_via_subprocess(
     _log_subprocess_environment(context.env)
     normalised_env = _normalise_environment(context.env)
     try:
-        process = subprocess.Popen(  # noqa: S603 - shell=False prevents injection; commands already parsed/validated
+        # This path owns `Popen` directly so relay threads can drain both pipes
+        # before the function returns.
+        process = subprocess.Popen(  # noqa: S603 # pylint: disable=consider-using-with
             command,
             cwd=None if context.cwd is None else str(context.cwd),
             env=normalised_env,

--- a/lading/commands/publish_plan.py
+++ b/lading/commands/publish_plan.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import collections.abc as cabc
 import dataclasses as dc
 import typing as typ
 
@@ -35,7 +36,7 @@ class PublishPlan:
 
 
 def _categorize_crates(
-    workspace_crates: typ.Sequence[WorkspaceCrate],
+    workspace_crates: cabc.Sequence[WorkspaceCrate],
     exclusion_set: set[str],
 ) -> tuple[list[WorkspaceCrate], list[WorkspaceCrate], list[WorkspaceCrate]]:
     """Split workspace crates into publishable and skipped categories."""
@@ -55,7 +56,7 @@ def _categorize_crates(
 
 
 def _process_order_and_collect_errors(
-    configured_order: typ.Sequence[str],
+    configured_order: cabc.Sequence[str],
     publishable_by_name: dict[str, WorkspaceCrate],
 ) -> tuple[list[WorkspaceCrate], set[str], set[str], list[str]]:
     """Collect ordering results and validation state for ``configured_order``."""
@@ -79,9 +80,9 @@ def _process_order_and_collect_errors(
 
 
 def _build_order_validation_messages(
-    duplicates: typ.AbstractSet[str],
-    unknown: typ.Sequence[str],
-    missing: typ.Sequence[str],
+    duplicates: cabc.Set[str],
+    unknown: cabc.Sequence[str],
+    missing: cabc.Sequence[str],
 ) -> list[str]:
     """Render validation failure messages for publish order problems."""
     messages: list[str] = []
@@ -102,7 +103,7 @@ def _build_order_validation_messages(
 
 def _resolve_configured_order(
     publishable_by_name: dict[str, WorkspaceCrate],
-    configured_order: typ.Sequence[str],
+    configured_order: cabc.Sequence[str],
 ) -> tuple[WorkspaceCrate, ...]:
     """Validate and return crates ordered according to configuration."""
     publishable_names = set(publishable_by_name)
@@ -212,10 +213,10 @@ def _format_crates_section(
 
 def _append_section[T](
     lines: list[str],
-    items: typ.Sequence[T],
+    items: cabc.Sequence[T],
     *,
     header: str,
-    formatter: typ.Callable[[T], str] = str,
+    formatter: cabc.Callable[[T], str] = str,
 ) -> None:
     """Append formatted ``items`` to ``lines`` when a section has content."""
     if items:

--- a/lading/config.py
+++ b/lading/config.py
@@ -2,11 +2,11 @@
 
 from __future__ import annotations
 
+import collections.abc as cabc
 import contextlib
 import contextvars
 import dataclasses as dc
 import typing as typ
-from collections import abc as cabc
 
 from cyclopts.config import Toml
 
@@ -19,24 +19,26 @@ CONFIG_FILENAME = "lading.toml"
 
 StripPatchesSetting = typ.Literal["all", "per-crate"] | bool
 
-CONFIG_ROOT_TOML_KEYS: typ.Final[frozenset[str]] = frozenset(
-    {"bump", "publish", "preflight"}
-)
+CONFIG_ROOT_TOML_KEYS: typ.Final[frozenset[str]] = frozenset({
+    "bump",
+    "publish",
+    "preflight",
+})
 BUMP_TOML_KEYS: typ.Final[frozenset[str]] = frozenset({"exclude", "documentation"})
 BUMP_DOCUMENTATION_TOML_KEYS: typ.Final[frozenset[str]] = frozenset({"globs"})
-PUBLISH_TOML_KEYS: typ.Final[frozenset[str]] = frozenset(
-    {"exclude", "order", "strip_patches"}
-)
-PREFLIGHT_TOML_KEYS: typ.Final[frozenset[str]] = frozenset(
-    {
-        "test_exclude",
-        "unit_tests_only",
-        "aux_build",
-        "compiletest_extern",
-        "env",
-        "stderr_tail_lines",
-    }
-)
+PUBLISH_TOML_KEYS: typ.Final[frozenset[str]] = frozenset({
+    "exclude",
+    "order",
+    "strip_patches",
+})
+PREFLIGHT_TOML_KEYS: typ.Final[frozenset[str]] = frozenset({
+    "test_exclude",
+    "unit_tests_only",
+    "aux_build",
+    "compiletest_extern",
+    "env",
+    "stderr_tail_lines",
+})
 
 
 class ConfigurationError(RuntimeError):
@@ -217,7 +219,8 @@ def _validate_mapping_keys(
         allowed_keys: Set of permitted key names.
         context: Context for error message (e.g., "bump", "publish").
 
-    Raises:
+    Raises
+    ------
         ConfigurationError: If mapping contains unknown keys.
 
     """
@@ -264,7 +267,7 @@ def load_configuration(workspace_root: Path) -> LadingConfig:
 
 
 @contextlib.contextmanager
-def use_configuration(configuration: LadingConfig) -> typ.Iterator[None]:
+def use_configuration(configuration: LadingConfig) -> cabc.Iterator[None]:
     """Set ``configuration`` as the active configuration for the current context."""
     token = _active_config.set(configuration)
     try:

--- a/lading/utils/process.py
+++ b/lading/utils/process.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import collections.abc as cabc
 import logging
 import shlex
 import typing as typ
@@ -17,7 +18,7 @@ else:  # pragma: no cover - type-only imports
 _LOGGER = logging.getLogger(__name__)
 
 
-def format_command(command: typ.Sequence[str]) -> str:
+def format_command(command: cabc.Sequence[str]) -> str:
     """Return a shell-style representation of ``command`` for logging."""
     if not command:
         _LOGGER.warning(
@@ -29,7 +30,7 @@ def format_command(command: typ.Sequence[str]) -> str:
 
 def log_command_invocation(
     logger: LoggerType,
-    command: typ.Sequence[str],
+    command: cabc.Sequence[str],
     cwd: PathType | None,
 ) -> None:
     """Log ``command`` with optional ``cwd`` using ``logger``."""

--- a/lading/workspace/metadata.py
+++ b/lading/workspace/metadata.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import collections.abc as cabc
 import json
 import logging
 import os
@@ -103,7 +104,7 @@ def _coerce_text(value: str | bytes) -> str:
 
 def load_cargo_metadata(
     workspace_root: Path | str | None = None,
-) -> typ.Mapping[str, typ.Any]:
+) -> cabc.Mapping[str, typ.Any]:
     """Execute ``cargo metadata`` and parse the resulting JSON payload."""
     command = _ensure_command()
     root_path = normalise_workspace_root(workspace_root)

--- a/lading/workspace/models.py
+++ b/lading/workspace/models.py
@@ -2,10 +2,10 @@
 
 from __future__ import annotations
 
+import collections.abc as cabc
 import dataclasses as dc
 import heapq
 import typing as typ
-from collections import abc as cabc
 from collections import defaultdict
 from pathlib import Path
 
@@ -84,13 +84,11 @@ class WorkspaceGraph(msgspec.Struct, frozen=True, kw_only=True):
         dependency_map: dict[str, tuple[str, ...]] = {}
         for crate in crates_by_name.values():
             dependency_names = tuple(
-                sorted(
-                    {
-                        dependency.name
-                        for dependency in crate.dependencies
-                        if _is_ordering_dependency(dependency, crates_by_name)
-                    }
-                )
+                sorted({
+                    dependency.name
+                    for dependency in crate.dependencies
+                    if _is_ordering_dependency(dependency, crates_by_name)
+                })
             )
             dependency_map[crate.name] = dependency_names
         return dependency_map

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -228,208 +228,124 @@ max-positional-arguments = 5
 # Keep this Pylint pass focused on the explicitly selected messages.
 disable = [
     "all",
-    # Existing process streaming code intentionally owns Popen lifecycle
-    # directly so stdout/stderr relay threads can finish before return.
-    "consider-using-with",
     # Managed PyPy is currently 3.11 while the project targets Python 3.13
     # syntax; keep PyPy-backed Pylint useful on files it can parse.
     "syntax-error",
 ]
 enable = [
-    # Catch invalid %-style specifiers before log calls reach production.
-    "logging-unsupported-format",
-    # Catch truncated %-style logging templates that cannot be formatted.
-    "logging-format-truncated",
-    # Reject log records that pass arguments with no matching placeholders.
-    "logging-too-many-args",
-    # Reject log records whose placeholders cannot all be populated.
-    "logging-too-few-args",
-    # Preserve lazy logging by passing interpolation values to the logger.
-    "logging-not-lazy",
-    # Discourage eager str.format calls in logging statements.
+    # Logging format safety.
     "logging-format-interpolation",
-    # Discourage eager f-string interpolation in logging statements.
+    "logging-format-truncated",
     "logging-fstring-interpolation",
-    # Prevent bare match captures from making later cases unreachable.
+    "logging-not-lazy",
+    "logging-too-few-args",
+    "logging-too-many-args",
+    "logging-unsupported-format",
+
+    # Pattern matching correctness and readability.
     "bare-name-capture-pattern",
-    # Ensure class pattern matching metadata has the required shape.
     "invalid-match-args-definition",
-    # Catch positional class patterns that exceed declared __match_args__.
-    "too-many-positional-sub-patterns",
-    # Reject duplicate attribute patterns in one class match.
-    "multiple-class-sub-patterns",
-    # Prefer whole-pattern class binding when that avoids extra lookups.
     "match-class-bind-self",
-    # Prefer explicit keyword class patterns over positional attributes.
     "match-class-positional-attributes",
-    # Keep adjacent isinstance checks compact and easier to scan.
-    "consider-merging-isinstance",
-    # Flag deeply nested control flow before functions become hard to audit.
-    "too-many-nested-blocks",
-    # Replace boolean-only if statements with direct boolean expressions.
-    "simplifiable-if-statement",
-    # Catch local bindings that accidentally shadow function parameters.
-    "redefined-argument-from-local",
-    # Remove redundant else blocks after unconditional returns.
-    "no-else-return",
-    # Prefer explicit ternary expressions over pre-ternary idioms.
-    "consider-using-ternary",
-    # Catch accidental one-item tuples caused by stray trailing commas.
-    "trailing-comma-tuple",
-    # Avoid StopIteration escaping generators under PEP 479.
-    "stop-iteration-return",
-    # Simplify redundant boolean expressions.
-    "simplify-boolean-expression",
-    # Keep return contracts explicit and consistent within each function.
-    "inconsistent-return-statements",
-    # Remove terminal return None statements that add no behaviour.
-    "useless-return",
-    # Prefer tuple unpacking for variable swaps.
-    "consider-swap-variables",
-    # Prefer str.join for iterable string assembly.
-    "consider-using-join",
-    # Prefer membership checks over repeated equality comparisons.
-    "consider-using-in",
-    # Prefer dict.get when retrieving optional dictionary values.
-    "consider-using-get",
-    # Prefer chained comparisons for ordered relationships.
+    "multiple-class-sub-patterns",
+    "too-many-positional-sub-patterns",
+
+    # Control-flow simplification.
     "chained-comparison",
-    # Prefer dictionary comprehensions over dict(list-comprehension) patterns.
-    "consider-using-dict-comprehension",
-    # Prefer set comprehensions over set(list-comprehension) patterns.
-    "consider-using-set-comprehension",
-    # Simplify boolean-only conditional expressions.
-    "simplifiable-if-expression",
-    # Remove redundant else blocks after unconditional raises.
-    "no-else-raise",
-    # Replace identity comprehensions with direct collection constructors.
-    "unnecessary-comprehension",
-    # Prefer sys.exit for explicit process termination.
-    "consider-using-sys-exit",
-    # Remove redundant else blocks after unconditional breaks.
-    "no-else-break",
-    # Remove redundant else blocks after unconditional continues.
-    "no-else-continue",
-    # Prefer Python 3 super() without explicit class and instance arguments.
-    "super-with-arguments",
-    # Simplify boolean conditions that have redundant structure.
-    "simplifiable-condition",
-    # Catch conditions that statically evaluate to constants.
     "condition-evals-to-constant",
-    # Prefer generators when a container is only consumed immediately.
-    "consider-using-generator",
-    # Avoid unnecessary comprehensions inside any/all/min/max/sum.
-    "use-a-generator",
-    # Prefer min() over equivalent conditional assignments.
-    "consider-using-min-builtin",
-    # Prefer max() over equivalent conditional assignments.
+    "consider-merging-isinstance",
+    "consider-swap-variables",
+    "consider-using-in",
     "consider-using-max-builtin",
-    # Avoid redundant dictionary lookups while iterating items.
-    "unnecessary-dict-index-lookup",
-    # Prefer [] for empty list creation.
-    "use-list-literal",
-    # Prefer {} for dictionary creation when a literal is clearer.
-    "use-dict-literal",
-    # Avoid redundant list index lookups while enumerating values.
-    "unnecessary-list-index-lookup",
-    # Prefer yield from for delegating iterable output.
-    "use-yield-from",
-    # Remove double negatives from boolean expressions.
+    "consider-using-min-builtin",
+    "consider-using-sys-exit",
+    "consider-using-ternary",
+    "inconsistent-return-statements",
+    "no-else-break",
+    "no-else-continue",
+    "no-else-raise",
+    "no-else-return",
+    "redefined-argument-from-local",
+    "simplifiable-condition",
+    "simplifiable-if-expression",
+    "simplifiable-if-statement",
+    "simplify-boolean-expression",
+    "stop-iteration-return",
+    "super-with-arguments",
+    "trailing-comma-tuple",
     "unnecessary-negation",
-    # Prefer enumerate over range(len(...)) loops.
-    "consider-using-enumerate",
-    # Iterate dictionaries directly instead of through keys().
+    "useless-return",
+
+    # Collection and iterator idioms.
     "consider-iterating-dictionary",
-    # Prefer dict.items() when both keys and values are used.
+    "consider-using-dict-comprehension",
     "consider-using-dict-items",
-    # Use maxsplit when only the first or last split component is needed.
-    "use-maxsplit-arg",
-    # Prefer sequence literals for repeated iteration values.
-    "use-sequence-for-iteration",
-    # Prefer f-strings for non-logging eager string interpolation.
+    "consider-using-enumerate",
     "consider-using-f-string",
-    # Prefer direct sequence truthiness over len(sequence).
-    "use-implicit-booleaness-not-len",
-    # Prefer direct sequence truthiness over comparison to an empty literal.
+    "consider-using-generator",
+    "consider-using-get",
+    "consider-using-join",
+    "consider-using-set-comprehension",
+    "unnecessary-comprehension",
+    "unnecessary-dict-index-lookup",
+    "unnecessary-list-index-lookup",
+    "use-a-generator",
+    "use-dict-literal",
     "use-implicit-booleaness-not-comparison",
-    # Prefer direct string truthiness over comparison to an empty string.
     "use-implicit-booleaness-not-comparison-to-string",
-    # Prefer operators and builtins over direct dunder calls.
-    "unnecessary-dunder-call",
-    # Avoid placeholder ellipses when a concrete stub body is clearer.
-    "unnecessary-ellipsis",
-    # Ensure environment helper calls receive string values.
-    "invalid-envvar-value",
-    # Use singledispatchmethod for method dispatch.
-    "singledispatch-method",
-    # Use singledispatch for function dispatch.
-    "singledispatchmethod-function",
-    # Catch invalid file open modes early.
+    "use-implicit-booleaness-not-len",
+    "use-list-literal",
+    "use-maxsplit-arg",
+    "use-sequence-for-iteration",
+    "use-yield-from",
+
+    # Runtime APIs, resources, and compatibility hazards.
     "bad-open-mode",
-    # Preserve compatibility awareness for datetime.time truthiness checks.
-    "boolean-datetime",
-    # Catch unittest assertions that cannot fail.
-    "redundant-unittest-assert",
-    # Ensure threading.Thread receives the target argument intentionally.
     "bad-thread-instantiation",
-    # Prefer os.environ.copy() over shallow-copying the environment proxy.
-    "shallow-copy-environ",
-    # Ensure os.getenv defaults have the expected string-or-None shape.
-    "invalid-envvar-default",
-    # Avoid preexec_fn because it can deadlock in threaded programs.
-    "subprocess-popen-preexec-fn",
-    # Require explicit subprocess.run check semantics.
-    "subprocess-run-check",
-    # Require explicit encodings for file I/O portability.
-    "unspecified-encoding",
-    # Keep breakpoint hooks out of committed code.
-    "forgotten-debug-statement",
-    # Avoid unbounded method caches that retain self indefinitely.
-    "method-cache-max-size-none",
-    # Surface deprecated stdlib method usage.
-    "deprecated-method",
-    # Surface deprecated stdlib argument usage.
+    "boolean-datetime",
+    "consider-using-with",
     "deprecated-argument",
-    # Surface deprecated stdlib class usage.
-    "deprecated-class",
-    # Surface deprecated stdlib decorator usage.
-    "deprecated-decorator",
-    # Surface deprecated stdlib attribute usage.
     "deprecated-attribute",
-    # Flag modules that have grown large enough to deserve splitting.
-    "too-many-lines",
-    # Keep trailing whitespace out of Python sources.
-    "trailing-whitespace",
-    # Require final newlines for stable text-file handling.
+    "deprecated-class",
+    "deprecated-decorator",
+    "deprecated-method",
+    "forgotten-debug-statement",
+    "invalid-envvar-default",
+    "invalid-envvar-value",
+    "method-cache-max-size-none",
+    "redundant-unittest-assert",
+    "shallow-copy-environ",
+    "singledispatch-method",
+    "singledispatchmethod-function",
+    "subprocess-popen-preexec-fn",
+    "subprocess-run-check",
+    "unnecessary-dunder-call",
+    "unnecessary-ellipsis",
+    "unspecified-encoding",
+
+    # Source layout and text hygiene.
     "missing-final-newline",
-    # Avoid excess blank lines at file end.
-    "trailing-newlines",
-    # Remove redundant parentheses around control-flow keywords.
-    "superfluous-parens",
-    # Catch mixed line endings before they create noisy diffs.
     "mixed-line-endings",
-    # Enforce the configured line-ending format.
+    "superfluous-parens",
+    "trailing-newlines",
+    "trailing-whitespace",
     "unexpected-line-ending-format",
-    # Prevent mutating dictionaries while iterating them.
+
+    # Mutation during iteration.
     "modified-iterating-dict",
-    # Prevent mutating sets while iterating them.
-    "modified-iterating-set",
-    # Flag list mutation during iteration, where behaviour is easy to miss.
     "modified-iterating-list",
-    # Keep public class surfaces small enough to understand.
-    "too-many-public-methods",
-    # Flag branch-heavy functions for refactoring.
-    "too-many-branches",
-    # Keep function signatures from accumulating too many parameters.
+    "modified-iterating-set",
+
+    # Structural complexity limits.
     "too-many-arguments",
-    # Flag functions whose local state has become hard to follow.
-    "too-many-locals",
-    # Flag functions that do too much sequential work.
-    "too-many-statements",
-    # Keep compound boolean conditions readable.
     "too-many-boolean-expressions",
-    # Keep positional call surfaces small and explicit.
+    "too-many-branches",
+    "too-many-lines",
+    "too-many-locals",
+    "too-many-nested-blocks",
     "too-many-positional-arguments",
+    "too-many-public-methods",
+    "too-many-statements",
 ]
 
 [tool.pytest.ini_options]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,9 +41,19 @@ dev = [
 
 [tool.ruff]
 line-length = 88
+preview = true
+target-version = "py313"
+extend-exclude = [
+    ".rules",
+    "docs",
+]
 
 [tool.ruff.format]
-exclude = ["tests/bdd/steps/test_bump_steps.py"]
+exclude = [
+    ".rules",
+    "docs",
+    "tests/bdd/steps/test_bump_steps.py",
+]
 
 [tool.ruff.lint]
 select = [
@@ -82,18 +92,47 @@ select = [
     "ANN",
     "C90",
     "PLR",
+    "PLE4703",
+    "PLR0202",
+    "PLR0203",
+    "PLR0914",
+    "PLR0916",
+    "PLR1702",
+    "PLR6104",
+    "PLR6201",
+    "PLR6301",
+    "PLW0108",
+    "RUF036",
+    "RUF053",
+    "RUF055",
+    "RUF064",
+    "RUF066",
 ]
 extend-ignore = [
     "D203",  # Conflicts with D211; prefer enforcing no blank line before class docstring.
     "D213",  # Conflicts with D212; keep summary on the first line.
+    "B903",  # Existing test doubles intentionally use lightweight classes.
+    "D420",  # Existing Google-style docstrings are not part of this lint import.
+    "FURB113",  # Existing append groups can be modernised separately.
+    "PLR0914",  # Existing functions exceed the imported local-variable ceiling.
+    "PLR6301",  # Existing helper methods retain instance-oriented grouping.
+    "PLW0108",  # Existing lambdas preserve local test monkeypatch clarity.
+    "RUF027",  # Existing template-string replacements intentionally use literals.
+    "RUF069",  # Existing float comparisons are exact parser expectations.
+    "S404",  # Existing subprocess wrappers are the intended process boundary.
+    "TC003",  # Type-only stdlib imports will be moved in a focused cleanup.
 ]
-per-file-ignores = {"**/test_*.py" = ["S101", "PLR0913", "PLR2004"]}
+[tool.ruff.lint.per-file-ignores]
+"**/test_*.py" = ["S101", "PLR0913", "PLR0917", "PLR2004", "PLR6301"]
+"tests/bdd/steps/*.py" = ["S101", "PLR0913", "PLR0917", "PLR2004", "PLR6301"]
 
 [tool.ruff.lint.mccabe]
-max-complexity = 9
+max-complexity = 8
 
 [tool.ruff.lint.pylint]
 max-args = 4
+max-bool-expr = 2
+max-locals = 10
 
 [tool.ruff.lint.flake8-import-conventions]
 # Declare the banned `from` imports.
@@ -121,6 +160,277 @@ datetime = "dt"
 "msgspec.json" = "msjson"
 typing = "typ"
 dataclasses = "dc"
+
+[tool.ruff.lint.flake8-tidy-imports.banned-api]
+"typing.AbstractSet".msg = "Use collections.abc.Set instead of deprecated typing generics."
+"typing.AsyncContextManager".msg = "Use contextlib.AbstractAsyncContextManager instead of deprecated typing generics."
+"typing.AsyncGenerator".msg = "Use collections.abc.AsyncGenerator instead of deprecated typing generics."
+"typing.AsyncIterable".msg = "Use collections.abc.AsyncIterable instead of deprecated typing generics."
+"typing.AsyncIterator".msg = "Use collections.abc.AsyncIterator instead of deprecated typing generics."
+"typing.Awaitable".msg = "Use collections.abc.Awaitable instead of deprecated typing generics."
+"typing.Callable".msg = "Use collections.abc.Callable instead of deprecated typing generics."
+"typing.ChainMap".msg = "Use collections.ChainMap instead of deprecated typing generics."
+"typing.Collection".msg = "Use collections.abc.Collection instead of deprecated typing generics."
+"typing.Container".msg = "Use collections.abc.Container instead of deprecated typing generics."
+"typing.ContextManager".msg = "Use contextlib.AbstractContextManager instead of deprecated typing generics."
+"typing.Coroutine".msg = "Use collections.abc.Coroutine instead of deprecated typing generics."
+"typing.Counter".msg = "Use collections.Counter instead of deprecated typing generics."
+"typing.DefaultDict".msg = "Use collections.defaultdict instead of deprecated typing generics."
+"typing.Deque".msg = "Use collections.deque instead of deprecated typing generics."
+"typing.Dict".msg = "Use dict instead of deprecated typing generics."
+"typing.FrozenSet".msg = "Use frozenset instead of deprecated typing generics."
+"typing.Generator".msg = "Use collections.abc.Generator instead of deprecated typing generics."
+"typing.ItemsView".msg = "Use collections.abc.ItemsView instead of deprecated typing generics."
+"typing.Iterable".msg = "Use collections.abc.Iterable instead of deprecated typing generics."
+"typing.Iterator".msg = "Use collections.abc.Iterator instead of deprecated typing generics."
+"typing.KeysView".msg = "Use collections.abc.KeysView instead of deprecated typing generics."
+"typing.List".msg = "Use list instead of deprecated typing generics."
+"typing.Mapping".msg = "Use collections.abc.Mapping instead of deprecated typing generics."
+"typing.Match".msg = "Use re.Match instead of deprecated typing generics."
+"typing.MutableMapping".msg = "Use collections.abc.MutableMapping instead of deprecated typing generics."
+"typing.MutableSequence".msg = "Use collections.abc.MutableSequence instead of deprecated typing generics."
+"typing.MutableSet".msg = "Use collections.abc.MutableSet instead of deprecated typing generics."
+"typing.OrderedDict".msg = "Use collections.OrderedDict instead of deprecated typing generics."
+"typing.Pattern".msg = "Use re.Pattern instead of deprecated typing generics."
+"typing.Reversible".msg = "Use collections.abc.Reversible instead of deprecated typing generics."
+"typing.Sequence".msg = "Use collections.abc.Sequence instead of deprecated typing generics."
+"typing.Set".msg = "Use set instead of deprecated typing generics."
+"typing.Tuple".msg = "Use tuple instead of deprecated typing generics."
+"typing.Type".msg = "Use type instead of deprecated typing generics."
+"typing.ValuesView".msg = "Use collections.abc.ValuesView instead of deprecated typing generics."
+
+[tool.ruff.lint.pydocstyle]
+# Enforce NumPy docstring style
+convention = "numpy"
+
+[tool.pylint.main]
+# Expand directory targets like lading and tests even when a target is not a
+# package.
+recursive = true
+# Keep Pylint's module-size check active without forcing an unrelated module
+# split while importing the second-tier lint action.
+max-module-lines = 800
+
+[tool.pylint.design]
+# Keep function call surfaces small enough to understand without memorising
+# positional argument order.
+max-args = 5
+# The new Pylint gate complements Ruff's stricter PLR0914 threshold without
+# forcing broad refactors while introducing the additional rule families below.
+max-locals = 20
+# Use Pylint's statement-count proxy for function length; Pylint 4 does not
+# expose a distinct physical-lines-per-function option.
+max-statements = 70
+# Keep positional call surfaces aligned with Ruff's existing argument limit.
+max-positional-arguments = 5
+
+[tool.pylint."messages control"]
+# Keep this Pylint pass focused on the explicitly selected messages.
+disable = [
+    "all",
+    # Existing process streaming code intentionally owns Popen lifecycle
+    # directly so stdout/stderr relay threads can finish before return.
+    "consider-using-with",
+    # Managed PyPy is currently 3.11 while the project targets Python 3.13
+    # syntax; keep PyPy-backed Pylint useful on files it can parse.
+    "syntax-error",
+]
+enable = [
+    # Catch invalid %-style specifiers before log calls reach production.
+    "logging-unsupported-format",
+    # Catch truncated %-style logging templates that cannot be formatted.
+    "logging-format-truncated",
+    # Reject log records that pass arguments with no matching placeholders.
+    "logging-too-many-args",
+    # Reject log records whose placeholders cannot all be populated.
+    "logging-too-few-args",
+    # Preserve lazy logging by passing interpolation values to the logger.
+    "logging-not-lazy",
+    # Discourage eager str.format calls in logging statements.
+    "logging-format-interpolation",
+    # Discourage eager f-string interpolation in logging statements.
+    "logging-fstring-interpolation",
+    # Prevent bare match captures from making later cases unreachable.
+    "bare-name-capture-pattern",
+    # Ensure class pattern matching metadata has the required shape.
+    "invalid-match-args-definition",
+    # Catch positional class patterns that exceed declared __match_args__.
+    "too-many-positional-sub-patterns",
+    # Reject duplicate attribute patterns in one class match.
+    "multiple-class-sub-patterns",
+    # Prefer whole-pattern class binding when that avoids extra lookups.
+    "match-class-bind-self",
+    # Prefer explicit keyword class patterns over positional attributes.
+    "match-class-positional-attributes",
+    # Keep adjacent isinstance checks compact and easier to scan.
+    "consider-merging-isinstance",
+    # Flag deeply nested control flow before functions become hard to audit.
+    "too-many-nested-blocks",
+    # Replace boolean-only if statements with direct boolean expressions.
+    "simplifiable-if-statement",
+    # Catch local bindings that accidentally shadow function parameters.
+    "redefined-argument-from-local",
+    # Remove redundant else blocks after unconditional returns.
+    "no-else-return",
+    # Prefer explicit ternary expressions over pre-ternary idioms.
+    "consider-using-ternary",
+    # Catch accidental one-item tuples caused by stray trailing commas.
+    "trailing-comma-tuple",
+    # Avoid StopIteration escaping generators under PEP 479.
+    "stop-iteration-return",
+    # Simplify redundant boolean expressions.
+    "simplify-boolean-expression",
+    # Keep return contracts explicit and consistent within each function.
+    "inconsistent-return-statements",
+    # Remove terminal return None statements that add no behaviour.
+    "useless-return",
+    # Prefer tuple unpacking for variable swaps.
+    "consider-swap-variables",
+    # Prefer str.join for iterable string assembly.
+    "consider-using-join",
+    # Prefer membership checks over repeated equality comparisons.
+    "consider-using-in",
+    # Prefer dict.get when retrieving optional dictionary values.
+    "consider-using-get",
+    # Prefer chained comparisons for ordered relationships.
+    "chained-comparison",
+    # Prefer dictionary comprehensions over dict(list-comprehension) patterns.
+    "consider-using-dict-comprehension",
+    # Prefer set comprehensions over set(list-comprehension) patterns.
+    "consider-using-set-comprehension",
+    # Simplify boolean-only conditional expressions.
+    "simplifiable-if-expression",
+    # Remove redundant else blocks after unconditional raises.
+    "no-else-raise",
+    # Replace identity comprehensions with direct collection constructors.
+    "unnecessary-comprehension",
+    # Prefer sys.exit for explicit process termination.
+    "consider-using-sys-exit",
+    # Remove redundant else blocks after unconditional breaks.
+    "no-else-break",
+    # Remove redundant else blocks after unconditional continues.
+    "no-else-continue",
+    # Prefer Python 3 super() without explicit class and instance arguments.
+    "super-with-arguments",
+    # Simplify boolean conditions that have redundant structure.
+    "simplifiable-condition",
+    # Catch conditions that statically evaluate to constants.
+    "condition-evals-to-constant",
+    # Prefer generators when a container is only consumed immediately.
+    "consider-using-generator",
+    # Avoid unnecessary comprehensions inside any/all/min/max/sum.
+    "use-a-generator",
+    # Prefer min() over equivalent conditional assignments.
+    "consider-using-min-builtin",
+    # Prefer max() over equivalent conditional assignments.
+    "consider-using-max-builtin",
+    # Avoid redundant dictionary lookups while iterating items.
+    "unnecessary-dict-index-lookup",
+    # Prefer [] for empty list creation.
+    "use-list-literal",
+    # Prefer {} for dictionary creation when a literal is clearer.
+    "use-dict-literal",
+    # Avoid redundant list index lookups while enumerating values.
+    "unnecessary-list-index-lookup",
+    # Prefer yield from for delegating iterable output.
+    "use-yield-from",
+    # Remove double negatives from boolean expressions.
+    "unnecessary-negation",
+    # Prefer enumerate over range(len(...)) loops.
+    "consider-using-enumerate",
+    # Iterate dictionaries directly instead of through keys().
+    "consider-iterating-dictionary",
+    # Prefer dict.items() when both keys and values are used.
+    "consider-using-dict-items",
+    # Use maxsplit when only the first or last split component is needed.
+    "use-maxsplit-arg",
+    # Prefer sequence literals for repeated iteration values.
+    "use-sequence-for-iteration",
+    # Prefer f-strings for non-logging eager string interpolation.
+    "consider-using-f-string",
+    # Prefer direct sequence truthiness over len(sequence).
+    "use-implicit-booleaness-not-len",
+    # Prefer direct sequence truthiness over comparison to an empty literal.
+    "use-implicit-booleaness-not-comparison",
+    # Prefer direct string truthiness over comparison to an empty string.
+    "use-implicit-booleaness-not-comparison-to-string",
+    # Prefer operators and builtins over direct dunder calls.
+    "unnecessary-dunder-call",
+    # Avoid placeholder ellipses when a concrete stub body is clearer.
+    "unnecessary-ellipsis",
+    # Ensure environment helper calls receive string values.
+    "invalid-envvar-value",
+    # Use singledispatchmethod for method dispatch.
+    "singledispatch-method",
+    # Use singledispatch for function dispatch.
+    "singledispatchmethod-function",
+    # Catch invalid file open modes early.
+    "bad-open-mode",
+    # Preserve compatibility awareness for datetime.time truthiness checks.
+    "boolean-datetime",
+    # Catch unittest assertions that cannot fail.
+    "redundant-unittest-assert",
+    # Ensure threading.Thread receives the target argument intentionally.
+    "bad-thread-instantiation",
+    # Prefer os.environ.copy() over shallow-copying the environment proxy.
+    "shallow-copy-environ",
+    # Ensure os.getenv defaults have the expected string-or-None shape.
+    "invalid-envvar-default",
+    # Avoid preexec_fn because it can deadlock in threaded programs.
+    "subprocess-popen-preexec-fn",
+    # Require explicit subprocess.run check semantics.
+    "subprocess-run-check",
+    # Require explicit encodings for file I/O portability.
+    "unspecified-encoding",
+    # Keep breakpoint hooks out of committed code.
+    "forgotten-debug-statement",
+    # Avoid unbounded method caches that retain self indefinitely.
+    "method-cache-max-size-none",
+    # Surface deprecated stdlib method usage.
+    "deprecated-method",
+    # Surface deprecated stdlib argument usage.
+    "deprecated-argument",
+    # Surface deprecated stdlib class usage.
+    "deprecated-class",
+    # Surface deprecated stdlib decorator usage.
+    "deprecated-decorator",
+    # Surface deprecated stdlib attribute usage.
+    "deprecated-attribute",
+    # Flag modules that have grown large enough to deserve splitting.
+    "too-many-lines",
+    # Keep trailing whitespace out of Python sources.
+    "trailing-whitespace",
+    # Require final newlines for stable text-file handling.
+    "missing-final-newline",
+    # Avoid excess blank lines at file end.
+    "trailing-newlines",
+    # Remove redundant parentheses around control-flow keywords.
+    "superfluous-parens",
+    # Catch mixed line endings before they create noisy diffs.
+    "mixed-line-endings",
+    # Enforce the configured line-ending format.
+    "unexpected-line-ending-format",
+    # Prevent mutating dictionaries while iterating them.
+    "modified-iterating-dict",
+    # Prevent mutating sets while iterating them.
+    "modified-iterating-set",
+    # Flag list mutation during iteration, where behaviour is easy to miss.
+    "modified-iterating-list",
+    # Keep public class surfaces small enough to understand.
+    "too-many-public-methods",
+    # Flag branch-heavy functions for refactoring.
+    "too-many-branches",
+    # Keep function signatures from accumulating too many parameters.
+    "too-many-arguments",
+    # Flag functions whose local state has become hard to follow.
+    "too-many-locals",
+    # Flag functions that do too much sequential work.
+    "too-many-statements",
+    # Keep compound boolean conditions readable.
+    "too-many-boolean-expressions",
+    # Keep positional call surfaces small and explicit.
+    "too-many-positional-arguments",
+]
 
 [tool.pytest.ini_options]
 # Tests automatically killed after seconds elapsed

--- a/tests/bdd/steps/metadata_fixtures.py
+++ b/tests/bdd/steps/metadata_fixtures.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import collections.abc as cabc
 import json
 import textwrap
 import typing as typ
@@ -23,7 +24,7 @@ if typ.TYPE_CHECKING:
 
 def _write_workspace_manifest(
     workspace_directory: Path,
-    members: typ.Sequence[str],
+    members: cabc.Sequence[str],
     version: str = "0.1.0",
 ) -> None:
     """Write a minimal workspace manifest for behavioural test fixtures.
@@ -65,8 +66,8 @@ def _write_workspace_readme(
 def _mock_cargo_metadata(
     cmd_mox: CmdMox,
     workspace_directory: Path,
-    packages: typ.Sequence[dict[str, typ.Any]],
-    member_ids: typ.Sequence[str],
+    packages: cabc.Sequence[dict[str, typ.Any]],
+    member_ids: cabc.Sequence[str],
 ) -> None:
     """Register a ``cargo metadata`` stub response for behavioural tests.
 
@@ -353,7 +354,7 @@ def given_cargo_metadata_with_internal_dependencies(
 
 def _install_publish_filter_metadata(
     workspace_directory: Path,
-    crate_specs: typ.Sequence[tuple[str, bool]],
+    crate_specs: cabc.Sequence[tuple[str, bool]],
     *,
     cmd_mox: CmdMox,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/bdd/steps/test_bump_steps.py
+++ b/tests/bdd/steps/test_bump_steps.py
@@ -56,6 +56,7 @@ def then_command_reports_workspace(
     assert "Updated version to " in stdout
     assert version in stdout
 
+
 @then(parsers.parse('the bump command reports no manifest changes for "{version}"'))
 def then_command_reports_no_changes(
     cli_run: dict[str, typ.Any],
@@ -66,6 +67,7 @@ def then_command_reports_no_changes(
     stdout = cli_run["stdout"]
     assert "No manifest changes required" in stdout
     assert f"already {version}" in stdout
+
 
 @then(parsers.parse('the bump command reports a dry-run plan for "{version}"'))
 def then_command_reports_dry_run(
@@ -78,6 +80,7 @@ def then_command_reports_dry_run(
     assert "Dry run;" in stdout
     assert f"would update version to {version}" in stdout
 
+
 @then(
     parsers.parse('the bump command reports an invalid version error for "{version}"')
 )
@@ -88,6 +91,7 @@ def then_bump_reports_invalid_version(
     assert cli_run["returncode"] == 1
     stderr = cli_run["stderr"]
     assert f"Invalid version argument '{version}'" in stderr
+
 
 @then(parsers.parse('the CLI output lists manifest paths "{first}" and "{second}"'))
 def then_cli_output_lists_manifest_paths(
@@ -102,6 +106,7 @@ def then_cli_output_lists_manifest_paths(
     manifest_lines = [line for line in stdout_lines if line.startswith("- ")]
     assert manifest_lines == expected_lines
 
+
 @then(parsers.parse('the CLI output lists documentation path "{expected}"'))
 def then_cli_output_lists_documentation_path(
     cli_run: dict[str, typ.Any], expected: str
@@ -110,6 +115,7 @@ def then_cli_output_lists_documentation_path(
     assert cli_run["returncode"] == 0
     stdout_lines = [line.strip() for line in cli_run["stdout"].splitlines()]
     assert expected in stdout_lines
+
 
 @then(parsers.parse('the documentation file "{relative_path}" contains "{expected}"'))
 def then_documentation_contains(

--- a/tests/bdd/steps/test_commands_catalogue_steps.py
+++ b/tests/bdd/steps/test_commands_catalogue_steps.py
@@ -72,7 +72,8 @@ def _parse_quoted_args(args_str: str) -> tuple[str, ...]:
     quoted strings. If shell-like escaping is required, consider using
     ``shlex.split`` instead.
 
-    Examples:
+    Examples
+    --------
         '"foo" "bar baz"' -> ("foo", "bar baz")
         '"" "bar"'        -> ("", "bar")
         'foo "bar"'       -> ValueError

--- a/tests/bdd/steps/test_publish_given_steps.py
+++ b/tests/bdd/steps/test_publish_given_steps.py
@@ -42,7 +42,7 @@ def given_cargo_check_fails(
     preflight_overrides: dict[tuple[str, ...], ResponseProvider],
 ) -> None:
     """Simulate a failing cargo check command."""
-    preflight_overrides[("cargo", "check", "--workspace", "--all-targets")] = (
+    preflight_overrides["cargo", "check", "--workspace", "--all-targets"] = (
         _CommandResponse(exit_code=1, stderr="cargo check failed")
     )
 
@@ -52,7 +52,7 @@ def given_cargo_test_fails(
     preflight_overrides: dict[tuple[str, ...], ResponseProvider],
 ) -> None:
     """Simulate a failing cargo test command."""
-    preflight_overrides[("cargo", "test", "--workspace")] = _CommandResponse(
+    preflight_overrides["cargo", "test", "--workspace"] = _CommandResponse(
         exit_code=1, stderr="cargo test failed"
     )
 
@@ -67,7 +67,7 @@ def given_cargo_test_fails_with_artifact(
     artifact = workspace_directory / relative_path
     artifact.parent.mkdir(parents=True, exist_ok=True)
     artifact.write_text("line1\nline2\n", encoding="utf-8")
-    preflight_overrides[("cargo", "test", "--workspace")] = _CommandResponse(
+    preflight_overrides["cargo", "test", "--workspace"] = _CommandResponse(
         exit_code=1,
         stderr=f"diff at {artifact}",
     )
@@ -99,7 +99,7 @@ def given_cargo_publish_already_uploaded(
             )
         return _CommandResponse(exit_code=0)
 
-    preflight_overrides[("cargo", "publish", "--dry-run")] = _handler
+    preflight_overrides["cargo", "publish", "--dry-run"] = _handler
 
 
 @given("the workspace has uncommitted changes")
@@ -107,7 +107,7 @@ def given_workspace_dirty(
     preflight_overrides: dict[tuple[str, ...], ResponseProvider],
 ) -> None:
     """Simulate a dirty working tree for git status."""
-    preflight_overrides[("git", "status", "--porcelain")] = _CommandResponse(
+    preflight_overrides["git", "status", "--porcelain"] = _CommandResponse(
         exit_code=0,
         stdout=" M Cargo.toml\n",
     )

--- a/tests/bdd/steps/test_publish_helpers.py
+++ b/tests/bdd/steps/test_publish_helpers.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import collections.abc as cabc
 import typing as typ
 from pathlib import Path
 
@@ -40,13 +41,13 @@ def _load_staged_manifest(cli_run: dict[str, typ.Any]) -> TOMLDocument:
     return toml_utils.load_manifest(manifest_path)
 
 
-def _get_patch_entries(document: typ.Mapping[str, typ.Any]) -> dict[str, typ.Any]:
+def _get_patch_entries(document: cabc.Mapping[str, typ.Any]) -> dict[str, typ.Any]:
     """Return the ``[patch.crates-io]`` mapping if it exists."""
     patch_table = document.get("patch")
-    if not isinstance(patch_table, typ.Mapping):
+    if not isinstance(patch_table, cabc.Mapping):
         return {}
     crates_io = patch_table.get("crates-io")
-    return dict(crates_io) if isinstance(crates_io, typ.Mapping) else {}
+    return dict(crates_io) if isinstance(crates_io, cabc.Mapping) else {}
 
 
 def _split_names(crate_names: str) -> list[str]:

--- a/tests/bdd/steps/test_publish_infrastructure.py
+++ b/tests/bdd/steps/test_publish_infrastructure.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import collections.abc as cabc
 import contextlib
 import dataclasses as dc
 import os
@@ -84,10 +85,10 @@ class PreflightTestContext:
 class _CmdInvocation(typ.Protocol):
     """Protocol describing the cmd-mox invocation payload."""
 
-    args: typ.Sequence[str]
+    args: cabc.Sequence[str]
 
 
-ResponseProvider = _CommandResponse | typ.Callable[[_CmdInvocation], _CommandResponse]
+ResponseProvider = _CommandResponse | cabc.Callable[[_CmdInvocation], _CommandResponse]
 
 
 def _validate_stub_arguments(
@@ -137,7 +138,7 @@ def _make_preflight_handler(
     expected_arguments: tuple[str, ...],
     recorder: _PreflightInvocationRecorder | None,
     label: str,
-) -> typ.Callable[[_CmdInvocation], tuple[str, str, int]]:
+) -> cabc.Callable[[_CmdInvocation], tuple[str, str, int]]:
     """Build a cmd-mox handler that validates argument prefixes."""
 
     def _handler(invocation: _CmdInvocation) -> tuple[str, str, int]:
@@ -252,7 +253,7 @@ def _build_env_restore_dict(var_name: str) -> dict[str, str]:
 
 
 @contextlib.contextmanager
-def _cmd_mox_stub_env_enabled() -> typ.Iterator[None]:
+def _cmd_mox_stub_env_enabled() -> cabc.Iterator[None]:
     """Temporarily enable CMD_MOX_STUB_ENV_VAR for cmd-mox stubs."""
     var_name = metadata_module.CMD_MOX_STUB_ENV_VAR
     restore = _build_env_restore_dict(var_name)

--- a/tests/bdd/steps/test_publish_when_steps.py
+++ b/tests/bdd/steps/test_publish_when_steps.py
@@ -77,7 +77,7 @@ def when_invoke_lading_publish_live(
         _is_cargo_publish_command(command)
         for command in preflight_test_context.overrides
     ):
-        preflight_test_context.overrides[("cargo", "publish")] = _CommandResponse(
+        preflight_test_context.overrides["cargo", "publish"] = _CommandResponse(
             exit_code=0
         )
     stub_config = preflight_test_context.create_stub_config()

--- a/tests/bdd/steps/test_workspace_metadata_steps.py
+++ b/tests/bdd/steps/test_workspace_metadata_steps.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import collections.abc as cabc
 import json
 import textwrap
 import typing as typ
@@ -45,14 +46,14 @@ def given_cargo_metadata_response(
 
 
 @when("I inspect the workspace metadata", target_fixture="metadata_payload")
-def when_inspect_metadata(workspace_directory: Path) -> typ.Mapping[str, typ.Any]:
+def when_inspect_metadata(workspace_directory: Path) -> cabc.Mapping[str, typ.Any]:
     """Execute the discovery helper against the stubbed command."""
     return load_cargo_metadata(workspace_directory)
 
 
 @then("the metadata payload contains the workspace root")
 def then_metadata_contains_workspace(
-    metadata_payload: typ.Mapping[str, typ.Any], workspace_directory: Path
+    metadata_payload: cabc.Mapping[str, typ.Any], workspace_directory: Path
 ) -> None:
     """Assert that the workspace root was parsed from the JSON payload."""
     assert metadata_payload["workspace_root"] == str(workspace_directory)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,9 +2,9 @@
 
 from __future__ import annotations
 
+import collections.abc as cabc
 import os
 import textwrap
-import typing as typ
 from pathlib import Path
 
 import pytest
@@ -30,7 +30,7 @@ def repo_root() -> Path:
 
 
 @pytest.fixture(autouse=True)
-def _restore_workspace_env() -> typ.Iterator[None]:
+def _restore_workspace_env() -> cabc.Iterator[None]:
     """Ensure tests do not leak ``LADING_WORKSPACE_ROOT`` between runs."""
     from lading.cli import WORKSPACE_ROOT_ENV_VAR
 
@@ -45,7 +45,7 @@ def _restore_workspace_env() -> typ.Iterator[None]:
 
 
 @pytest.fixture
-def write_config(tmp_path: Path) -> typ.Callable[[str], Path]:
+def write_config(tmp_path: Path) -> cabc.Callable[[str], Path]:
     """Return a helper that writes ``lading.toml`` into ``tmp_path``."""
     from lading import config as config_module
 
@@ -58,7 +58,7 @@ def write_config(tmp_path: Path) -> typ.Callable[[str], Path]:
 
 
 @pytest.fixture
-def minimal_config(write_config: typ.Callable[[str], Path]) -> Path:
+def minimal_config(write_config: cabc.Callable[[str], Path]) -> Path:
     """Persist a representative configuration file for CLI exercises."""
     return write_config(
         """

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import collections.abc as cabc
 import typing as typ
 
 import pytest
@@ -47,7 +48,7 @@ def e2e_workspace_with_git(
 
 
 @pytest.fixture
-def staging_cleanup() -> typ.Callable[[Path], None]:
+def staging_cleanup() -> cabc.Callable[[Path], None]:
     """Return a helper that removes the publish staging directory parent."""
 
     def _cleanup(staging_root: Path) -> None:

--- a/tests/e2e/helpers/e2e_steps_helpers.py
+++ b/tests/e2e/helpers/e2e_steps_helpers.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import collections.abc as cabc
 import json
 import os
 import sys
@@ -18,8 +19,8 @@ if typ.TYPE_CHECKING:  # pragma: no cover
 
 
 class _CmdMoxInvocation(typ.Protocol):
-    args: typ.Sequence[str]
-    env: typ.Mapping[str, str]
+    args: cabc.Sequence[str]
+    env: cabc.Mapping[str, str]
 
 
 class E2EExpectationError(AssertionError):

--- a/tests/e2e/helpers/git_helpers.py
+++ b/tests/e2e/helpers/git_helpers.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import shutil
 import typing as typ
+from contextlib import suppress
 
 from plumbum import local
 
@@ -80,7 +81,5 @@ def git_is_clean(repo_path: Path) -> bool:
 
 def rmtree(path: Path) -> None:
     """Remove ``path`` recursively, ignoring missing paths."""
-    try:
+    with suppress(FileNotFoundError):
         shutil.rmtree(path)
-    except FileNotFoundError:
-        return

--- a/tests/e2e/helpers/workspace_builder.py
+++ b/tests/e2e/helpers/workspace_builder.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import collections.abc as cabc
 import dataclasses as dc
 import json
 import textwrap
@@ -20,7 +21,7 @@ class NonTrivialWorkspace:
     root: Path
     version: str
     crate_names: tuple[str, ...]
-    cargo_metadata_payload: typ.Mapping[str, typ.Any]
+    cargo_metadata_payload: cabc.Mapping[str, typ.Any]
 
 
 def create_nontrivial_workspace(
@@ -181,7 +182,7 @@ def _build_cargo_metadata_payload(
     *,
     version: str,
     manifests: dict[str, Path],
-) -> typ.Mapping[str, typ.Any]:
+) -> cabc.Mapping[str, typ.Any]:
     """Return a cargo metadata JSON payload describing the fixture workspace."""
     workspace_members = [f"{name}-id" for name in ("core", "utils", "app")]
     packages: list[dict[str, typ.Any]] = [

--- a/tests/e2e/steps/test_e2e_steps.py
+++ b/tests/e2e/steps/test_e2e_steps.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import collections.abc as cabc
 import typing as typ
 from pathlib import Path
 
@@ -50,7 +51,7 @@ def _create_recording_handler(
     expected_prefixes: tuple[tuple[str, ...], ...] = (),
     *,
     require_target_dir: bool = False,
-) -> typ.Callable[[CmdMoxInvocation], tuple[str, str, int]]:
+) -> cabc.Callable[[CmdMoxInvocation], tuple[str, str, int]]:
     """Create an invocation handler that validates and records cmd-mox calls."""
 
     def _handler(invocation: CmdMoxInvocation) -> tuple[str, str, int]:
@@ -280,7 +281,7 @@ def then_cargo_publish_omits_allow_dirty(publish_spies: dict[str, typ.Any]) -> N
 def then_readme_staged(
     cli_run: dict[str, typ.Any],
     publish_spies: dict[str, typ.Any],
-    staging_cleanup: typ.Callable[[Path], None],
+    staging_cleanup: cabc.Callable[[Path], None],
 ) -> None:
     """Assert publish staging copied the workspace README into each crate."""
     workspace: workspace_builder.NonTrivialWorkspace = publish_spies["workspace"]

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import collections.abc as cabc
 import typing as typ
 from dataclasses import dataclass  # noqa: ICN003
 
@@ -32,10 +33,10 @@ class PublishFixtures:
     """Bundle reusable publish helpers to trim fixture fan-out."""
 
     tmp_path: Path
-    make_crate: typ.Callable[[Path, str, _CrateSpec | None], WorkspaceCrate]
-    make_workspace: typ.Callable[[Path, WorkspaceCrate], WorkspaceGraph]
-    make_config: typ.Callable[..., config_module.LadingConfig]
-    make_dependency: typ.Callable[[str], WorkspaceDependency]
+    make_crate: cabc.Callable[[Path, str, _CrateSpec | None], WorkspaceCrate]
+    make_workspace: cabc.Callable[[Path, WorkspaceCrate], WorkspaceGraph]
+    make_config: cabc.Callable[..., config_module.LadingConfig]
+    make_dependency: cabc.Callable[[str], WorkspaceDependency]
     publish_options: publish.PublishOptions
 
 
@@ -55,7 +56,7 @@ def disable_publish_preflight(monkeypatch: pytest.MonkeyPatch) -> None:
 
 
 @pytest.fixture
-def make_config() -> typ.Callable[..., config_module.LadingConfig]:
+def make_config() -> cabc.Callable[..., config_module.LadingConfig]:
     """Return a factory for publish-friendly configuration objects."""
 
     def _make_config(
@@ -80,7 +81,7 @@ def make_config() -> typ.Callable[..., config_module.LadingConfig]:
 
 
 @pytest.fixture
-def make_crate() -> typ.Callable[[Path, str, _CrateSpec | None], WorkspaceCrate]:
+def make_crate() -> cabc.Callable[[Path, str, _CrateSpec | None], WorkspaceCrate]:
     """Return a factory that materialises temporary workspace crates."""
 
     def _make_crate(
@@ -121,8 +122,8 @@ def make_crate() -> typ.Callable[[Path, str, _CrateSpec | None], WorkspaceCrate]
 
 @pytest.fixture
 def make_workspace(
-    make_crate: typ.Callable[[Path, str, _CrateSpec | None], WorkspaceCrate],
-) -> typ.Callable[[Path, WorkspaceCrate], WorkspaceGraph]:
+    make_crate: cabc.Callable[[Path, str, _CrateSpec | None], WorkspaceCrate],
+) -> cabc.Callable[[Path, WorkspaceCrate], WorkspaceGraph]:
     """Return a factory that assembles workspace graphs for tests."""
 
     def _make_workspace(root: Path, *crates: WorkspaceCrate) -> WorkspaceGraph:
@@ -166,7 +167,7 @@ def preparation_fixtures(publish_fixtures: PublishFixtures) -> PreparationFixtur
 
 
 @pytest.fixture
-def make_dependency() -> typ.Callable[[str], WorkspaceDependency]:
+def make_dependency() -> cabc.Callable[[str], WorkspaceDependency]:
     """Return a factory for workspace dependency records."""
 
     def _make_dependency(name: str) -> WorkspaceDependency:

--- a/tests/unit/publish/conftest.py
+++ b/tests/unit/publish/conftest.py
@@ -31,7 +31,8 @@ def make_preflight_config(**overrides: object) -> config_module.PreflightConfig:
             Special handling: compiletest_externs as tuple of (name, path) pairs
             will be converted to CompiletestExtern objects.
 
-    Returns:
+    Returns
+    -------
         A PreflightConfig with defaults merged with the provided overrides.
 
     """

--- a/tests/unit/publish/preflight_test_utils.py
+++ b/tests/unit/publish/preflight_test_utils.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import collections.abc as cabc
 import typing as typ
 from pathlib import Path
 
@@ -15,7 +16,7 @@ if typ.TYPE_CHECKING:
     from lading import config as config_module
     from lading.workspace import WorkspaceGraph
 
-CallRecord = tuple[tuple[str, ...], Path | None, typ.Mapping[str, str] | None]
+CallRecord = tuple[tuple[str, ...], Path | None, cabc.Mapping[str, str] | None]
 RecordedCommands = list[CallRecord]
 
 
@@ -23,7 +24,7 @@ def _setup_preflight_test(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
     configuration: config_module.LadingConfig,
-    crate_names: typ.Sequence[str] | None = None,
+    crate_names: cabc.Sequence[str] | None = None,
 ) -> tuple[Path, WorkspaceGraph, RecordedCommands]:
     """Execute ``publish.run`` with optional workspace crates and capture calls."""
     monkeypatch.setattr(publish, "_run_preflight_checks", ORIGINAL_PREFLIGHT)
@@ -36,10 +37,10 @@ def _setup_preflight_test(
     calls: RecordedCommands = []
 
     def recording_invoke(
-        command: typ.Sequence[str],
+        command: cabc.Sequence[str],
         *,
         cwd: Path | None = None,
-        env: typ.Mapping[str, str] | None = None,
+        env: cabc.Mapping[str, str] | None = None,
     ) -> tuple[int, str, str]:
         calls.append((tuple(command), cwd, env))
         return 0, "", ""

--- a/tests/unit/publish/test_packaging.py
+++ b/tests/unit/publish/test_packaging.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import collections.abc as cabc
 import logging
 import typing as typ
 

--- a/tests/unit/publish/test_preflight_checks.py
+++ b/tests/unit/publish/test_preflight_checks.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import collections.abc as cabc
 import typing as typ
 
 import pytest
@@ -90,7 +91,7 @@ def test_run_cargo_preflight_raises_on_failure(
         command: tuple[str, ...],
         *,
         cwd: Path | None = None,
-        env: typ.Mapping[str, str] | None = None,
+        env: cabc.Mapping[str, str] | None = None,
     ) -> tuple[int, str, str]:
         assert cwd == tmp_path
         assert command[0] == "cargo"
@@ -116,7 +117,8 @@ def _run_and_record_cargo_preflight(
 ) -> tuple[str, ...]:
     """Run cargo preflight with a recording runner and return the command.
 
-    Returns:
+    Returns
+    -------
         The recorded cargo command as a tuple of strings.
 
     """
@@ -126,7 +128,7 @@ def _run_and_record_cargo_preflight(
         command: tuple[str, ...],
         *,
         cwd: Path | None = None,
-        env: typ.Mapping[str, str] | None = None,
+        env: cabc.Mapping[str, str] | None = None,
     ) -> tuple[int, str, str]:
         recorded.append(command)
         return 0, "", ""
@@ -301,7 +303,7 @@ def test_preflight_runs_aux_build_commands(
         command: tuple[str, ...],
         *,
         cwd: Path | None = None,
-        env: typ.Mapping[str, str] | None = None,
+        env: cabc.Mapping[str, str] | None = None,
     ) -> tuple[int, str, str]:
         commands.append((tuple(command), cwd))
         return 0, "", ""
@@ -340,7 +342,7 @@ def test_aux_build_failure_surfaces_error(
         command: tuple[str, ...],
         *,
         cwd: Path | None = None,
-        env: typ.Mapping[str, str] | None = None,
+        env: cabc.Mapping[str, str] | None = None,
     ) -> tuple[int, str, str]:
         if tuple(command) == failing_command:
             return 1, "", "aux failure"
@@ -379,7 +381,7 @@ def test_preflight_env_overrides_forwarded(
         command: tuple[str, ...],
         *,
         cwd: Path | None = None,
-        env: typ.Mapping[str, str] | None = None,
+        env: cabc.Mapping[str, str] | None = None,
     ) -> tuple[int, str, str]:
         if command[:2] == ("cargo", "test"):
             captured_env.update(env or {})
@@ -418,7 +420,7 @@ def test_preflight_append_compiletest_externs(
         command: tuple[str, ...],
         *,
         cwd: Path | None = None,
-        env: typ.Mapping[str, str] | None = None,
+        env: cabc.Mapping[str, str] | None = None,
     ) -> tuple[int, str, str]:
         # Decompose complex conditional into readable business rules
         is_cargo_test = command[:2] == ("cargo", "test")
@@ -465,7 +467,7 @@ def test_compiletest_diagnostic_details(
         command: tuple[str, ...],
         *,
         cwd: Path | None = None,
-        env: typ.Mapping[str, str] | None = None,
+        env: cabc.Mapping[str, str] | None = None,
     ) -> tuple[int, str, str]:
         return 1, f"diff at {artifact}", ""
 
@@ -498,7 +500,7 @@ def test_verify_clean_working_tree_detects_dirty_state(
         command: tuple[str, ...],
         *,
         cwd: Path | None = None,
-        env: typ.Mapping[str, str] | None = None,
+        env: cabc.Mapping[str, str] | None = None,
     ) -> tuple[int, str, str]:
         assert cwd == root
         return 0, " M file\n", ""
@@ -521,7 +523,7 @@ def test_verify_clean_working_tree_reports_missing_repo(
         command: tuple[str, ...],
         *,
         cwd: Path | None = None,
-        env: typ.Mapping[str, str] | None = None,
+        env: cabc.Mapping[str, str] | None = None,
     ) -> tuple[int, str, str]:
         assert command == ("git", "status", "--porcelain")
         assert cwd == tmp_path

--- a/tests/unit/publish/test_publish_execution_helpers.py
+++ b/tests/unit/publish/test_publish_execution_helpers.py
@@ -403,9 +403,10 @@ def test_log_subprocess_environment_redacts_sensitive_values(
     """Environment logging should redact common secret tokens."""
     caplog.set_level("DEBUG", logger="lading.commands.publish_execution")
 
-    publish_execution._log_subprocess_environment(
-        {"TOKEN": "secret", "PATH": "/usr/bin"}
-    )
+    publish_execution._log_subprocess_environment({
+        "TOKEN": "secret",
+        "PATH": "/usr/bin",
+    })
 
     assert "PATH" in caplog.text
     assert "<redacted>" in caplog.text

--- a/tests/unit/publish/test_run_integration.py
+++ b/tests/unit/publish/test_run_integration.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-import typing as typ
+import collections.abc as cabc
 from pathlib import Path
 
 import pytest
@@ -218,10 +218,10 @@ def test_run_executes_preflight_checks_in_workspace(
     calls: list[tuple[tuple[str, ...], Path | None]] = []
 
     def fake_invoke(
-        command: typ.Sequence[str],
+        command: cabc.Sequence[str],
         *,
         cwd: Path | None = None,
-        env: typ.Mapping[str, str] | None = None,
+        env: cabc.Mapping[str, str] | None = None,
     ) -> tuple[int, str, str]:
         calls.append((tuple(command), cwd))
         return 0, "", ""
@@ -366,10 +366,10 @@ def test_dirty_workspace_allowed_by_default(
     configuration = make_config()
 
     def skip_git_invoke(
-        command: typ.Sequence[str],
+        command: cabc.Sequence[str],
         *,
         cwd: Path | None = None,
-        env: typ.Mapping[str, str] | None = None,
+        env: cabc.Mapping[str, str] | None = None,
     ) -> tuple[int, str, str]:
         if command[0] == "git":
             message = "git status should be skipped by default"
@@ -394,10 +394,10 @@ def test_forbid_dirty_flag_enforces_cleanliness(
     configuration = make_config()
 
     def dirty_invoke(
-        command: typ.Sequence[str],
+        command: cabc.Sequence[str],
         *,
         cwd: Path | None = None,
-        env: typ.Mapping[str, str] | None = None,
+        env: cabc.Mapping[str, str] | None = None,
     ) -> tuple[int, str, str]:
         if command[0] == "git":
             return 0, " M Cargo.toml\n", ""
@@ -438,10 +438,10 @@ def test_run_raises_when_preflight_cargo_fails(
     configuration = make_config()
 
     def failing_invoke(
-        command: typ.Sequence[str],
+        command: cabc.Sequence[str],
         *,
         cwd: Path | None = None,
-        env: typ.Mapping[str, str] | None = None,
+        env: cabc.Mapping[str, str] | None = None,
     ) -> tuple[int, str, str]:
         if command[0] == "git":
             return 0, "", ""

--- a/tests/unit/test_bump_command_internals.py
+++ b/tests/unit/test_bump_command_internals.py
@@ -91,7 +91,8 @@ def _make_workspace_with_alpha_dependency(
         dependency: Tuple of (dependency_name, dependency_version) for beta's
             dependency.
 
-    Returns:
+    Returns
+    -------
         Tuple of (beta_crate, workspace_graph).
 
     """
@@ -131,7 +132,8 @@ def _parse_manifest_versions(
     Args:
         manifest_path: Path to the Cargo.toml manifest.
 
-    Returns:
+    Returns
+    -------
         Tuple of (package_version, alpha_dependency_version).
 
     """

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import collections.abc as cabc
 import dataclasses as dc
 import io
 import logging
@@ -24,7 +25,7 @@ if typ.TYPE_CHECKING:
 
 
 @contextmanager
-def _preserve_root_logger() -> typ.Iterator[logging.Logger]:
+def _preserve_root_logger() -> cabc.Iterator[logging.Logger]:
     """Capture and restore the root logger configuration around a test."""
     root_logger = logging.getLogger()
     prior_handlers = list(root_logger.handlers)
@@ -128,7 +129,7 @@ def test_configure_logging_installs_named_handler(
     ],
 )
 def test_extract_workspace_override(
-    tokens: typ.Sequence[str],
+    tokens: cabc.Sequence[str],
     expected_workspace: str | None,
     expected_remaining: list[str],
 ) -> None:
@@ -377,15 +378,13 @@ def test_bump_cli_accepts_dry_run_flag(
     monkeypatch.setattr(bump_command, "run", fake_run)
     monkeypatch.setattr(cli, "load_workspace", lambda _: workspace_graph)
 
-    exit_code = cli.main(
-        [
-            "--workspace-root",
-            str(tmp_path),
-            "bump",
-            "1.2.3",
-            "--dry-run",
-        ]
-    )
+    exit_code = cli.main([
+        "--workspace-root",
+        str(tmp_path),
+        "bump",
+        "1.2.3",
+        "--dry-run",
+    ])
 
     assert exit_code == 0
     options = captured_kwargs["options"]
@@ -417,7 +416,7 @@ def test_main_handles_exceptions(
 ) -> None:
     """Handle exceptions during command execution."""
 
-    def boom(_: typ.Sequence[str]) -> int:
+    def boom(_: cabc.Sequence[str]) -> int:
         raise case.exception
 
     monkeypatch.setattr(cli, "_dispatch_and_print", boom)

--- a/tests/unit/test_publish_formatting.py
+++ b/tests/unit/test_publish_formatting.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import collections.abc as cabc
 import typing as typ
 
 from lading.commands import publish
@@ -53,7 +54,7 @@ def test_append_section_omits_header_for_empty_sequences() -> None:
 
 def test_format_plan_formats_skipped_sections(
     tmp_path: Path,
-    make_crate: typ.Callable[[Path, str, _CrateSpec | None], WorkspaceCrate],
+    make_crate: cabc.Callable[[Path, str, _CrateSpec | None], WorkspaceCrate],
 ) -> None:
     """``_format_plan`` renders skipped crates using their names only."""
     root = tmp_path.resolve()

--- a/tests/unit/test_publish_patch_strategy.py
+++ b/tests/unit/test_publish_patch_strategy.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import collections.abc as cabc
 import dataclasses as dc
 import typing as typ
 
@@ -23,7 +24,7 @@ class _PatchStrategyTestSetup:
     """Parameters for patch strategy test setup."""
 
     tmp_path: Path
-    make_plan_factory: typ.Callable[[Path, tuple[str, ...]], publish.PublishPlan]
+    make_plan_factory: cabc.Callable[[Path, tuple[str, ...]], publish.PublishPlan]
     patch_entries: str
     publishable_names: tuple[str, ...]
     strategy: str | bool
@@ -31,8 +32,8 @@ class _PatchStrategyTestSetup:
 
 @pytest.fixture
 def make_plan_factory(
-    make_crate: typ.Callable[[Path, str, object | None], WorkspaceCrate],
-) -> typ.Callable[[Path, tuple[str, ...]], publish.PublishPlan]:
+    make_crate: cabc.Callable[[Path, str, object | None], WorkspaceCrate],
+) -> cabc.Callable[[Path, tuple[str, ...]], publish.PublishPlan]:
     """Return a factory for building publish plans rooted at ``workspace_root``."""
 
     def _builder(
@@ -83,7 +84,7 @@ def _apply_strategy_and_parse(setup: _PatchStrategyTestSetup) -> TOMLDocument:
 
 def test_strip_patches_all_removes_patch_section(
     tmp_path: Path,
-    make_plan_factory: typ.Callable[[Path, tuple[str, ...]], publish.PublishPlan],
+    make_plan_factory: cabc.Callable[[Path, tuple[str, ...]], publish.PublishPlan],
 ) -> None:
     """Strategy 'all' removes the entire [patch.crates-io] section."""
     document = _apply_strategy_and_parse(
@@ -100,7 +101,7 @@ def test_strip_patches_all_removes_patch_section(
 
 def test_strip_patches_per_crate_removes_publishable_only(
     tmp_path: Path,
-    make_plan_factory: typ.Callable[[Path, tuple[str, ...]], publish.PublishPlan],
+    make_plan_factory: cabc.Callable[[Path, tuple[str, ...]], publish.PublishPlan],
 ) -> None:
     """Strategy 'per-crate' removes only entries for publishable crates."""
     document = _apply_strategy_and_parse(
@@ -124,7 +125,7 @@ def test_strip_patches_per_crate_removes_publishable_only(
 
 def test_strip_patches_per_crate_removes_entire_table_when_empty(
     tmp_path: Path,
-    make_plan_factory: typ.Callable[[Path, tuple[str, ...]], publish.PublishPlan],
+    make_plan_factory: cabc.Callable[[Path, tuple[str, ...]], publish.PublishPlan],
 ) -> None:
     """Per-crate strategy cleans up empty patch tables after removals."""
     document = _apply_strategy_and_parse(
@@ -145,7 +146,7 @@ def test_strip_patches_per_crate_removes_entire_table_when_empty(
 
 def test_strip_patches_disabled_keeps_section(
     tmp_path: Path,
-    make_plan_factory: typ.Callable[[Path, tuple[str, ...]], publish.PublishPlan],
+    make_plan_factory: cabc.Callable[[Path, tuple[str, ...]], publish.PublishPlan],
 ) -> None:
     """Boolean false leaves the patch section untouched."""
     document = _apply_strategy_and_parse(

--- a/tests/unit/test_publish_planning.py
+++ b/tests/unit/test_publish_planning.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import collections.abc as cabc
 import typing as typ
 
 import pytest
@@ -18,8 +19,8 @@ if typ.TYPE_CHECKING:
 
 def _plan_with_crates(
     tmp_path: Path,
-    make_workspace: typ.Callable[[Path, WorkspaceCrate], WorkspaceGraph],
-    make_config: typ.Callable[..., config_module.LadingConfig],
+    make_workspace: cabc.Callable[[Path, WorkspaceCrate], WorkspaceGraph],
+    make_config: cabc.Callable[..., config_module.LadingConfig],
     crates: tuple[WorkspaceCrate, ...],
     **config_overrides: object,
 ) -> publish.PublishPlan:
@@ -33,8 +34,8 @@ def _plan_with_crates(
 def _make_dependency_chain(
     root: Path,
     *,
-    make_crate: typ.Callable[[Path, str, _CrateSpec | None], WorkspaceCrate],
-    make_dependency: typ.Callable[[str], WorkspaceDependency],
+    make_crate: cabc.Callable[[Path, str, _CrateSpec | None], WorkspaceCrate],
+    make_dependency: cabc.Callable[[str], WorkspaceDependency],
 ) -> tuple[WorkspaceCrate, WorkspaceCrate, WorkspaceCrate]:
     """Return crates that form a simple alpha→beta→gamma dependency chain."""
     alpha = make_crate(root, "alpha")
@@ -140,7 +141,7 @@ def test_plan_publication_filtering(
 
 def test_plan_publication_empty_workspace(
     tmp_path: Path,
-    make_config: typ.Callable[..., config_module.LadingConfig],
+    make_config: cabc.Callable[..., config_module.LadingConfig],
 ) -> None:
     """Planner returns empty results when the workspace has no crates."""
     from lading.workspace import WorkspaceGraph

--- a/tests/unit/test_publish_staging.py
+++ b/tests/unit/test_publish_staging.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import collections.abc as cabc
 import dataclasses as dc
 import typing as typ
 
@@ -198,8 +199,8 @@ def test_stage_workspace_readmes_returns_empty_list_when_unused(
 )
 def test_collect_workspace_readme_targets_by_opt_in(
     tmp_path: Path,
-    make_crate: typ.Callable[[Path, str, _CrateSpec | None], WorkspaceCrate],
-    make_workspace: typ.Callable[[Path, WorkspaceCrate], WorkspaceGraph],
+    make_crate: cabc.Callable[[Path, str, _CrateSpec | None], WorkspaceCrate],
+    make_workspace: cabc.Callable[[Path, WorkspaceCrate], WorkspaceGraph],
     scenario: dict[str, bool | int],
 ) -> None:
     """Collection includes only crates with readme.workspace = true."""
@@ -221,7 +222,7 @@ def test_collect_workspace_readme_targets_by_opt_in(
 
 def test_stage_workspace_readmes_copies_and_sorts_targets(
     tmp_path: Path,
-    make_crate: typ.Callable[[Path, str, _CrateSpec | None], WorkspaceCrate],
+    make_crate: cabc.Callable[[Path, str, _CrateSpec | None], WorkspaceCrate],
 ) -> None:
     """Workspace README is copied into each opted-in crate in sorted order."""
     workspace_root = tmp_path / "workspace"
@@ -268,7 +269,7 @@ def test_stage_workspace_readmes_copies_and_sorts_targets(
 )
 def test_stage_workspace_readmes_validation_errors(
     tmp_path: Path,
-    make_crate: typ.Callable[[Path, str, _CrateSpec | None], WorkspaceCrate],
+    make_crate: cabc.Callable[[Path, str, _CrateSpec | None], WorkspaceCrate],
     case: _StageReadmeValidationCase,
 ) -> None:
     """Staging readmes validates workspace README existence and crate location."""
@@ -361,9 +362,9 @@ def test_prepare_workspace_registers_cleanup(
     plan = publish.plan_publication(workspace, pf.make_config())
 
     build_directory = fx.publish_options.build_directory
-    registered: list[typ.Callable[[], None]] = []
+    registered: list[cabc.Callable[[], None]] = []
 
-    def capture(callback: typ.Callable[[], None]) -> None:
+    def capture(callback: cabc.Callable[[], None]) -> None:
         registered.append(callback)
 
     monkeypatch.setattr(publish.atexit, "register", capture)
@@ -445,9 +446,9 @@ def test_prepare_workspace_does_not_register_cleanup_when_disabled(
     workspace = pf.make_workspace(workspace_root, crate)
     plan = publish.plan_publication(workspace, pf.make_config())
 
-    registered: list[typ.Callable[[], None]] = []
+    registered: list[cabc.Callable[[], None]] = []
 
-    def capture(callback: typ.Callable[[], None]) -> None:
+    def capture(callback: cabc.Callable[[], None]) -> None:
         registered.append(callback)
 
     monkeypatch.setattr(publish.atexit, "register", capture)

--- a/tests/unit/test_workspace_models_validation.py
+++ b/tests/unit/test_workspace_models_validation.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import collections.abc as cabc
 import typing as typ
 
 import pytest
@@ -69,7 +70,7 @@ def test_build_dependencies_handles_missing_entries() -> None:
     ],
 )
 def test_dependency_validation_errors(
-    callable_obj: typ.Callable[..., object], args: tuple[object, ...]
+    callable_obj: cabc.Callable[..., object], args: tuple[object, ...]
 ) -> None:
     """Invalid dependency shapes should raise WorkspaceModelError."""
     with pytest.raises(models.WorkspaceModelError):


### PR DESCRIPTION
## Summary

This branch imports the lint policy used by `leynos/episodic` so Lading runs Ruff first and then a focused Pylint pass through the PyPy shim. It raises the project lint baseline while keeping existing large-module and test-scaffolding debt explicit instead of folding broad refactors into the tooling change.

No linked issue or roadmap task was identified for this branch.

## Review walkthrough

- Start with [Makefile](https://github.com/leynos/lading/blob/1c44627f78b58e0b2336c95bf8c870356d3950d1/Makefile) to see the new `pylint-pypy-shim` command wiring and the second lint tier after Ruff.
- Then review [pyproject.toml](https://github.com/leynos/lading/blob/1c44627f78b58e0b2336c95bf8c870356d3950d1/pyproject.toml) for the imported Ruff selections, Pylint message allow-list, local thresholds, and formatter exclusions for documentation examples.
- Finish with representative annotation migrations such as [lading/commands/publish_plan.py](https://github.com/leynos/lading/blob/1c44627f78b58e0b2336c95bf8c870356d3950d1/lading/commands/publish_plan.py), plus the corresponding test updates under [tests](https://github.com/leynos/lading/tree/1c44627f78b58e0b2336c95bf8c870356d3950d1/tests), to verify the `typing` banned-api rule is satisfied without behaviour changes.

## Validation

- `make lint`: passed, including Ruff and PyPy-backed Pylint.
- `make check-fmt`: passed.
- `make typecheck`: passed.
- `make test`: passed, 432 tests.
- `git diff --check`: passed.

## Notes

- The imported Pylint pass keeps module size, argument-count, and resource-lifecycle thresholds explicit, but avoids forcing unrelated module splits in this branch.
- Ruff excludes [docs](https://github.com/leynos/lading/tree/1c44627f78b58e0b2336c95bf8c870356d3950d1/docs) and [.rules](https://github.com/leynos/lading/tree/1c44627f78b58e0b2336c95bf8c870356d3950d1/.rules) from formatter traversal so existing prose examples are not rewritten as part of this tooling import.

## References

- Lody session: https://lody.ai/leynos/sessions/5eb12d49-6dcd-43cc-8e0e-7a06b9b41c8f