### PR TITLE
Interleave live publish packaging (#59)

### DIFF
--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -192,6 +192,36 @@ single `lading publish` run. Its fields are:
 The dataclass is an internal implementation detail; callers interact with the
 public `PublishOptions` dataclass, which `run()` converts before dispatching.
 
+### Publication orchestration helpers
+
+`_validate_publication_options(options)` is the first publish-specific guard in
+`run()`. It rejects invalid option combinations before workspace loading or
+staging begins. Today that means `live=True` cannot be combined with
+`allow_unpublished_workspace_deps=True`, because the sibling-dependency
+index-lookup downgrade is only valid for dry-run workflows.
+
+`_execute_live_publication_pipeline(plan, preparation, *, options, runner)` is
+the live-mode dispatcher. It walks `PublishPlan.publishable` in order and runs
+`cargo package` followed by `cargo publish` for each crate before advancing to
+the next crate. It logs per-crate progress, records completed crates for abort
+diagnostics, and normalises staging/preparation failures into
+`PublishPreflightError` so callers receive the same publish command error
+boundary.
+
+`_handle_publish_result(invocation, crate, plan, options)` owns the result
+classification for a completed `cargo publish` command. It logs success,
+skips already-published crate versions, delegates in-plan crates.io index
+visibility failures to `_handle_index_missing_version`, and raises
+`PublishError` for all other non-zero publish exits after formatting the cargo
+failure message.
+
+`_CargoPreflightOptions` lives in `publish_preflight.py` and carries the
+per-invocation settings for cargo pre-flight commands: extra cargo arguments,
+test exclusions, unit-test-only narrowing, environment overrides, and optional
+stderr-tail diagnostics. `_run_preflight_checks` builds these option objects
+for `cargo check` and `cargo test` so command construction stays explicit and
+testable.
+
 Publication dispatch deliberately differs by mode. Dry-run mode keeps the
 historical two-phase pipeline: package every publishable crate, then run
 `cargo publish --dry-run` for every crate. Live mode interleaves the pipeline

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -177,6 +177,37 @@ to handle both validation and publish-phase failures through one `except`
 clause, or catch `PublishError` first when publish-phase failures require
 distinct handling.
 
+### Extracted publish modules
+
+`publish_plan.py` owns publication planning and plan rendering. Its
+`PublishPlan` dataclass is the immutable boundary between workspace analysis
+and execution: it stores the workspace root, publishable crates in the resolved
+order, crates skipped by manifest/configuration, and configured exclusions
+that did not match a workspace crate. `plan_publication()` builds that object
+by filtering non-publishable crates, applying `publish.exclude`, validating
+`publish.order` when present, or deriving a deterministic dependency order.
+
+`publish_manifest.py` owns staging-time manifest mutations. It contains the
+workspace preparation types and helpers that copy the workspace tree, stage
+workspace README files for crates that opt in, and apply the
+`publish.strip_patches` strategy to the staged `Cargo.toml`. These operations
+run before any `cargo package` or `cargo publish` command so the command runner
+works against a prepared snapshot rather than the source workspace.
+
+`publish_diagnostics.py` owns compiletest failure enrichment. When a cargo
+pre-flight test failure mentions compiletest-style `*.stderr` artefacts, the
+diagnostic helper locates the referenced files, tails a bounded number of
+lines, and appends those snippets to the `PublishPreflightError` message. The
+module is deliberately read-only: missing artefacts or unreadable files produce
+diagnostic notes rather than replacing the original cargo failure.
+
+`publish_index_check.py` owns crates.io index-lookup classification. It
+contains `_CargoInvocation`, the predicates and parsers that recognise Cargo's
+"no matching package/version" diagnostics, crate-name canonicalization, and
+`_handle_index_missing_version()`. That handler decides whether an index miss
+is out-of-plan and fatal, in-plan but still fatal, or in-plan and downgraded by
+`allow_unpublished_workspace_deps` during dry-run publication.
+
 ### `_PublishExecutionOptions`
 
 `_PublishExecutionOptions` is a frozen dataclass that carries the runtime flags
@@ -309,24 +340,29 @@ own target directory. A non-zero exit from any step raises
 ### Per-crate publication helpers
 
 `_package_crate` and `_publish_crate` are the atomic units of the
-publication pipeline. Both accept a `CrateEntry` and a
-`_PublicationPipelineContext` and execute exactly one `cargo` invocation
-against the crate's staging root:
+publication pipeline. Both accept the crate entry, publication state, and
+command runner explicitly, then execute exactly one `cargo` invocation against
+the crate's staging root:
 
 ```python
-_package_crate(crate: CrateEntry, context: _PublicationPipelineContext) -> None
-_publish_crate(crate: CrateEntry, context: _PublicationPipelineContext) -> None
+_package_crate(
+    crate: WorkspaceCrate,
+    state: _PublicationPipelineState,
+    *,
+    runner: _CommandRunner,
+) -> None
+_publish_crate(
+    crate: WorkspaceCrate,
+    state: _PublicationPipelineState,
+    *,
+    runner: _CommandRunner,
+) -> None
 ```
 
-`_PublicationPipelineContext` is a frozen dataclass that groups the four
-inputs shared across every per-crate call within a single `run()` invocation:
-
-| Field | Type | Purpose |
-| --- | --- | --- |
-| `plan` | `PublishPlan` | Resolved publication plan including the `publishable` crate list. |
-| `preparation` | `PublishPreparation` | Staging workspace metadata including `staging_root`. |
-| `options` | `_PublishExecutionOptions` | Runtime flags (`live`, `allow_dirty`, `allow_unpublished_workspace_deps`). |
-| `runner` | `_CommandRunner` | Injectable command runner; defaults to `_invoke` in production. |
+`_PublicationPipelineState` carries only publish-domain state: the resolved
+`PublishPlan`, the `PublishPreparation`, and `_PublishExecutionOptions`.
+Infrastructure stays at the call boundary: `_CommandRunner` is passed directly
+to each pipeline/helper function rather than being bundled into the state.
 
 `_dispatch_publication` selects the live or dry-run pipeline and delegates
 accordingly. It is the sole branch that decides between the interleaved

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -232,6 +232,51 @@ includes all four values. Using a single function for message construction keeps
 the error format consistent across the packaging and publish phases and makes
 snapshot testing straightforward.
 
+### Publish exception types
+
+Two public exception types are raised from the publish workflow, defined in
+:mod:`lading.commands.publish_errors` and re-exported from
+:mod:`lading.commands.publish`.
+
+#### `PublishPreflightError`
+
+Raised when pre-publication checks cannot prove the workspace is ready to
+publish. This covers packaging failures, missing index entries (when the
+allow-unpublished-workspace-deps override is not set or not applicable), dirty
+working trees, and cargo check/test failures. It is the **outermost** catch
+boundary: all publish failures, including those from the publish phase, can be
+handled as `PublishPreflightError`.
+
+```python
+from lading.commands.publish import PublishPreflightError, run
+
+try:
+    run(Path("/workspace"), configuration)
+except PublishPreflightError as exc:
+    print(f"Publish aborted: {exc}")
+```
+
+#### `PublishError`
+
+Subclasses `PublishPreflightError` and is raised specifically when
+`cargo publish` fails after pre-flight checks have succeeded. This lets callers
+distinguish packaging (pre-flight) failures from upload (publish) failures
+while still allowing a single catch-all:
+
+```python
+from lading.commands.publish import PublishError, PublishPreflightError, run
+
+try:
+    run(Path("/workspace"), configuration, options=PublishOptions(live=True))
+except PublishError as exc:
+    print(f"Upload failed after checks: {exc}")
+except PublishPreflightError as exc:
+    print(f"Pre-flight check failed: {exc}")
+```
+
+Both classes inherit from `RuntimeError`, carry their message through the
+standard `args` tuple, and avoid additional mutable state.
+
 `lading.commands.publish_execution` loads the optional `cmd_mox` command-runner
 module with `importlib.import_module("cmd_mox.command_runner")`. Keeping the
 module in an `object | None` variable avoids relying on

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -161,6 +161,22 @@ yet. When enabled, `lading publish` downgrades that specific index-lookup
 failure to a warning and continues. The option is rejected at runtime when
 `live=True`, so it cannot mask a real upload failure.
 
+### Exception hierarchy (`publish_errors`)
+
+`lading.commands.publish_errors` defines the public error boundary for
+publish orchestration. Both classes inherit from `RuntimeError` and carry
+their message through the standard `args` tuple.
+
+| Exception | Raised when |
+| --- | --- |
+| `PublishPreflightError` | A local check fails before publication begins — dirty working tree, auxiliary build failure, failed `cargo check`/`cargo test` preflight, or an invalid option combination (e.g. `--live` combined with `--allow-unpublished-workspace-deps`). |
+| `PublishError` | A `cargo publish` invocation fails after pre-flight checks have passed. Subclasses `PublishPreflightError`. |
+
+Callers of `lading.commands.publish.run` may catch `PublishPreflightError`
+to handle both validation and publish-phase failures through one `except`
+clause, or catch `PublishError` first when publish-phase failures require
+distinct handling.
+
 ### `_PublishExecutionOptions`
 
 `_PublishExecutionOptions` is a frozen dataclass that carries the runtime flags
@@ -231,51 +247,6 @@ exit code, and the `(stdout, stderr)` pair, it returns a formatted message that
 includes all four values. Using a single function for message construction keeps
 the error format consistent across the packaging and publish phases and makes
 snapshot testing straightforward.
-
-### Publish exception types
-
-Two public exception types are raised from the publish workflow, defined in
-:mod:`lading.commands.publish_errors` and re-exported from
-:mod:`lading.commands.publish`.
-
-#### `PublishPreflightError`
-
-Raised when pre-publication checks cannot prove the workspace is ready to
-publish. This covers packaging failures, missing index entries (when the
-allow-unpublished-workspace-deps override is not set or not applicable), dirty
-working trees, and cargo check/test failures. It is the **outermost** catch
-boundary: all publish failures, including those from the publish phase, can be
-handled as `PublishPreflightError`.
-
-```python
-from lading.commands.publish import PublishPreflightError, run
-
-try:
-    run(Path("/workspace"), configuration)
-except PublishPreflightError as exc:
-    print(f"Publish aborted: {exc}")
-```
-
-#### `PublishError`
-
-Subclasses `PublishPreflightError` and is raised specifically when
-`cargo publish` fails after pre-flight checks have succeeded. This lets callers
-distinguish packaging (pre-flight) failures from upload (publish) failures
-while still allowing a single catch-all:
-
-```python
-from lading.commands.publish import PublishError, PublishPreflightError, run
-
-try:
-    run(Path("/workspace"), configuration, options=PublishOptions(live=True))
-except PublishError as exc:
-    print(f"Upload failed after checks: {exc}")
-except PublishPreflightError as exc:
-    print(f"Pre-flight check failed: {exc}")
-```
-
-Both classes inherit from `RuntimeError`, carry their message through the
-standard `args` tuple, and avoid additional mutable state.
 
 `lading.commands.publish_execution` loads the optional `cmd_mox` command-runner
 module with `importlib.import_module("cmd_mox.command_runner")`. Keeping the

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -176,6 +176,16 @@ single `lading publish` run. Its fields are:
 The dataclass is an internal implementation detail; callers interact with the
 public `PublishOptions` dataclass, which `run()` converts before dispatching.
 
+Publication dispatch deliberately differs by mode. Dry-run mode keeps the
+historical two-phase pipeline: package every publishable crate, then run
+`cargo publish --dry-run` for every crate. Live mode interleaves the pipeline
+per crate: package the next crate, publish it, then advance to the next entry
+in `PublishPlan.publishable`. That ordering lets dependent crates resolve newly
+uploaded in-plan dependencies during a single live release train. The live
+pipeline does not roll back earlier uploads if a later crate fails; reruns rely
+on the already-published detection path to log and skip versions already
+visible in the registry.
+
 The index-lookup handling is split across three helpers:
 
 - `_is_index_missing_version_error(exit_code, stdout, stderr) -> bool` checks

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -204,7 +204,7 @@ index-lookup downgrade is only valid for dry-run workflows.
 the live-mode dispatcher. It walks `PublishPlan.publishable` in order and runs
 `cargo package` followed by `cargo publish` for each crate before advancing to
 the next crate. It logs per-crate progress, records completed crates for abort
-diagnostics, and normalises staging/preparation failures into
+diagnostics, and normalizes staging/preparation failures into
 `PublishPreflightError` so callers receive the same publish command error
 boundary.
 

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -191,7 +191,7 @@ by filtering non-publishable crates, applying `publish.exclude`, validating
 workspace preparation types and helpers that copy the workspace tree, stage
 workspace README files for crates that opt in, and apply the
 `publish.strip_patches` strategy to the staged `Cargo.toml`. These operations
-run before any `cargo package` or `cargo publish` command so the command runner
+run before any `cargo package` or `cargo publish` command, so the command runner
 works against a prepared snapshot rather than the source workspace.
 
 `publish_diagnostics.py` owns compiletest failure enrichment. When a cargo
@@ -202,7 +202,7 @@ module is deliberately read-only: missing artefacts or unreadable files produce
 diagnostic notes rather than replacing the original cargo failure.
 
 `publish_index_check.py` owns crates.io index-lookup classification. It
-contains `_CargoInvocation`, the predicates and parsers that recognise Cargo's
+contains `_CargoInvocation`, the predicates and parsers that recognize Cargo's
 "no matching package/version" diagnostics, crate-name canonicalization, and
 `_handle_index_missing_version()`. That handler decides whether an index miss
 is out-of-plan and fatal, in-plan but still fatal, or in-plan and downgraded by

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -248,6 +248,61 @@ includes all four values. Using a single function for message construction keeps
 the error format consistent across the packaging and publish phases and makes
 snapshot testing straightforward.
 
+### Pre-flight validation (`publish_preflight`)
+
+`lading.commands.publish_preflight` performs workspace validation before
+any crate is packaged or published. Its public entry point is:
+
+```python
+_run_preflight_checks(
+    workspace_root: Path,
+    *,
+    allow_dirty: bool,
+    configuration: LadingConfig,
+    runner: _CommandRunner | None = None,
+) -> None
+```
+
+The function verifies the git working tree is clean (unless `allow_dirty`
+is set), then executes `cargo check` and `cargo test` in a temporary
+`--target-dir` to keep preflight artefacts separate from the workspace's
+own target directory. A non-zero exit from any step raises
+`PublishPreflightError` with a descriptive message.
+
+| Helper | Purpose |
+| --- | --- |
+| `_compose_preflight_arguments` | Builds the base `cargo` argument tuple for a given target directory and `--all-targets` flag. |
+| `_preflight_argument_sets` | Returns `(check_args, test_args)` tuples adapted for unit-test-only mode. |
+| `_run_cargo_preflight` | Executes a single `cargo check` or `cargo test` invocation and raises on failure. |
+| `_verify_clean_working_tree` | Runs `git status --porcelain` and raises if the tree is dirty and `allow_dirty` is `False`. |
+
+### Per-crate publication helpers
+
+`_package_crate` and `_publish_crate` are the atomic units of the
+publication pipeline. Both accept a `CrateEntry` and a
+`_PublicationPipelineContext` and execute exactly one `cargo` invocation
+against the crate's staging root:
+
+```python
+_package_crate(crate: CrateEntry, context: _PublicationPipelineContext) -> None
+_publish_crate(crate: CrateEntry, context: _PublicationPipelineContext) -> None
+```
+
+`_PublicationPipelineContext` is a frozen dataclass that groups the four
+inputs shared across every per-crate call within a single `run()` invocation:
+
+| Field | Type | Purpose |
+| --- | --- | --- |
+| `plan` | `PublishPlan` | Resolved publication plan including the `publishable` crate list. |
+| `preparation` | `PublishPreparation` | Staging workspace metadata including `staging_root`. |
+| `options` | `_PublishExecutionOptions` | Runtime flags (`live`, `allow_dirty`, `allow_unpublished_workspace_deps`). |
+| `runner` | `_CommandRunner` | Injectable command runner; defaults to `_invoke` in production. |
+
+`_dispatch_publication` selects the live or dry-run pipeline and delegates
+accordingly. It is the sole branch that decides between the interleaved
+per-crate flow and the historical two-phase batch flow, keeping `run()`
+free of that decision.
+
 `lading.commands.publish_execution` loads the optional `cmd_mox` command-runner
 module with `importlib.import_module("cmd_mox.command_runner")`. Keeping the
 module in an `object | None` variable avoids relying on

--- a/docs/lading-design.md
+++ b/docs/lading-design.md
@@ -389,7 +389,9 @@ lading publish [--live] [--forbid-dirty]
 
 - `--live`: By default, the command simulates the entire process, including
   `cargo package` and `cargo publish --dry-run`, without uploading to the
-  registry. Specifying `--live` takes the process to completion.
+  registry. Specifying `--live` takes the process to completion by packaging
+  and publishing each crate before moving to the next crate in the publish
+  order.
 - `--forbid-dirty`: Require a clean working tree before running the pre-flight
   checks. When omitted the git status guard is skipped so that developers can
   iterate on pending changes.
@@ -512,7 +514,8 @@ sequenceDiagram
 
 ### Publishing iteration
 
-1. **Iterate and publish:** For each crate in the determined order:
+1. **Prepare staged workspace:** Apply patch stripping and README staging in
+   the temporary workspace before invoking Cargo for individual crates.
 
     - **Patch Handling (per-crate)**: If strip_patches is "per-crate" (or is
       unset and this is a live run), remove the specific patch entry for the
@@ -520,13 +523,23 @@ sequenceDiagram
       prepared for packaging.
     - **README Handling:** If the crate has `readme.workspace = true`, copy the
       workspace `README.md` into the crate's directory prior to packaging.
-    - **Package:** Run `cargo package` to create the `.crate` file and verify
-      its contents.
-    - **Publish:** Run `cargo publish`. The command defaults to `--dry-run`
-      so operators can validate the full pipeline safely; passing `--live`
-      omits the flag and performs a real upload. When the registry reports
-      that a crate version already exists, Lading logs a warning and
-      continues to the next crate instead of aborting the publication loop.
+
+2. **Dispatch Cargo operations:** The publish mode determines how Cargo is
+   invoked for the planned crate order.
+
+    - **Dry-run:** Run `cargo package` for every publishable crate first, then
+      run `cargo publish --dry-run` for every crate. This validates the full
+      batch without uploading anything.
+    - **Live:** For each crate, run `cargo package` and then `cargo publish`
+      before moving to the next crate. This makes a newly uploaded earlier
+      crate visible to later crates that depend on it in the same release
+      train.
+
+    When the registry reports that a crate version already exists, Lading logs
+    a warning and continues to the next crate instead of aborting the
+    publication loop. Live publishing is not transactional: if a later crate
+    fails, any earlier successful uploads remain on crates.io and are skipped
+    on a subsequent run.
 
 ## 5. Refactoring and Project Structure
 

--- a/docs/lading-design.md
+++ b/docs/lading-design.md
@@ -524,7 +524,7 @@ sequenceDiagram
     - **README Handling:** If the crate has `readme.workspace = true`, copy the
       workspace `README.md` into the crate's directory prior to packaging.
 
-2. **Dispatch Cargo operations:** The publish mode determines how Cargo is
+2. **Dispatch Cargo operations:** The publishing mode determines how Cargo is
    invoked for the planned crate order.
 
     - **Dry-run:** Run `cargo package` for every publishable crate first, then

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -205,7 +205,8 @@ interacting with the `cargo publish` command.
 - [x] **Implement `cargo publish` Execution:**
 
   - **Outcome:** The command executes `cargo publish` for each crate,
-    supporting both dry-run and live modes. The
+    supporting both batched dry-run mode and interleaved per-crate live mode
+    for internal dependency release trains (closes `#59`). The
     `--allow-unpublished-workspace-deps` dry-run-only flag (closes `#60`)
     downgrades index-lookup failures for in-plan workspace dependencies to
     warnings, enabling CI dry-run workflows on multi-crate release trains.

--- a/docs/users-guide.md
+++ b/docs/users-guide.md
@@ -9,6 +9,16 @@ workspaces. It can:
 - Plan and execute publication (`cargo package` + `cargo publish`) in dependency
   order, with pre-flight `cargo check`/`cargo test` validation.
 
+> **Breaking change in 0.1.0 — `--live` interleaving**
+>
+> Prior to 0.1.0, `lading publish --live` ran a two-phase pipeline: all
+> crates were packaged before any were published. From 0.1.0 onwards the
+> live pipeline is interleaved — each crate is packaged and published in
+> turn before the next crate is processed. Dry-run mode retains the
+> original two-phase order. Workspaces that relied on the old sequencing
+> must adopt the new per-crate ordering; no configuration knob restores
+> the prior behaviour.
+
 ## Installation
 
 ### Install from a wheel (recommended for internal distribution)

--- a/docs/users-guide.md
+++ b/docs/users-guide.md
@@ -128,9 +128,9 @@ Plain dry-runs still use Cargo's live index and may need the override below.
 
 ##### Manual staged publishing
 
-If you need to split a release manually, run `lading publish --live` for the
+When a release must be split manually, run `lading publish --live` for the
 foundational crate first, then run `lading publish` (dry-run) or
-`lading publish --live` for the rest of the workspace once the new version is
+`lading publish --live` for the remaining workspace once the new version is
 indexed:
 
 ```bash

--- a/docs/users-guide.md
+++ b/docs/users-guide.md
@@ -89,6 +89,15 @@ To perform a real publish (no `--dry-run`), pass `--live`:
 lading publish --live
 ```
 
+Dry-run publishing packages every publishable crate first, then runs
+`cargo publish --dry-run` for every crate. Live publishing follows
+`publish.order` crate by crate: `cargo package`, then `cargo publish`, then the
+next crate. This lets a later crate depend on a newly published earlier crate
+in the same `--live` run. Live publishing is not transactional; if a later
+crate fails, crates already uploaded to crates.io are not rolled back. Reruns
+skip versions that are already present on crates.io and continue with the
+remaining crates.
+
 `publish` stages the workspace into a temporary directory before packaging. If
 any member crate sets `readme.workspace = true`, `lading` copies the workspace
 `README.md` into that crate in the staged workspace so `cargo package` can
@@ -111,21 +120,18 @@ Caused by:
   required by package `outer_crate v0.8.0`
 ```
 
-This affects release trains that introduce a new shared version across multiple
-workspace crates. Setting `publish.order` to package the foundational crate
-first does **not** bypass this limitation, because each crate is still packaged
-against the live crates.io index rather than the locally packaged sibling.
+This affects dry-run release trains that introduce a new shared version across
+multiple workspace crates. `lading publish --live` avoids the limitation by
+publishing each crate immediately after it is packaged, so a later crate can
+resolve a dependency that an earlier crate in `publish.order` just uploaded.
+Plain dry-runs still use Cargo's live index and may need the override below.
 
-##### Workarounds
+##### Manual staged publishing
 
-Two patterns avoid the issue. Both require an initial real publish for the
-foundational crate, so its new version becomes visible on crates.io.
-
-###### Staged publish
-
-Run `lading publish --live` for the foundational crate first, then run
-`lading publish` (dry-run) or `lading publish --live` for the rest of the
-workspace once the new version is indexed:
+If you need to split a release manually, run `lading publish --live` for the
+foundational crate first, then run `lading publish` (dry-run) or
+`lading publish --live` for the rest of the workspace once the new version is
+indexed:
 
 ```bash
 
@@ -138,34 +144,6 @@ lading publish --workspace-root path/to/workspace
 
 `lading` skips crates whose versions are already on crates.io, so the second
 invocation only acts on the remaining crates.
-
-###### Temporary `publish.exclude`
-
-Exclude dependent crates from the first run, publish the foundational crate,
-then remove the exclusion and run again:
-
-```toml
-
-# lading.toml during the first publish
-[publish]
-order = ["inner_crate", "outer_crate"]
-exclude = ["outer_crate"]
-```
-
-```bash
-lading publish --live
-```
-
-After the foundational crate is indexed, restore `lading.toml`:
-
-```toml
-[publish]
-order = ["inner_crate", "outer_crate"]
-```
-
-```bash
-lading publish # or `lading publish --live`
-```
 
 ##### `--allow-unpublished-workspace-deps` (dry-run only)
 

--- a/lading/commands/publish.py
+++ b/lading/commands/publish.py
@@ -506,7 +506,7 @@ def _handle_publish_result(
     """Handle a completed ``cargo publish`` invocation."""
     exit_code, stdout, stderr = invocation.output
     if exit_code == 0:
-        LOGGER.info("Successfully published crate %s", crate.name)
+        LOGGER.info("Successfully published crate %s", invocation.crate_name)
         return
     if _is_already_published_error(exit_code, stdout, stderr):
         LOGGER.warning(

--- a/lading/commands/publish.py
+++ b/lading/commands/publish.py
@@ -287,16 +287,25 @@ def prepare_workspace(
     build_directory = _normalise_build_directory(
         plan.workspace_root, active_options.build_directory
     )
+    LOGGER.info(
+        "Preparing staged workspace for publication under %s",
+        build_directory,
+    )
     staging_root = _copy_workspace_tree(
         plan.workspace_root,
         build_directory,
         preserve_symlinks=active_options.preserve_symlinks,
     )
+    LOGGER.info("Staged workspace created at %s", staging_root)
     readme_crates = _collect_workspace_readme_targets(workspace)
     copied_readmes = _stage_workspace_readmes(
         crates=readme_crates,
         workspace_root=plan.workspace_root,
         staging_root=staging_root,
+    )
+    LOGGER.info(
+        "Workspace README staging complete: %d files copied",
+        len(copied_readmes),
     )
     preparation = PublishPreparation(
         staging_root=staging_root, copied_readmes=copied_readmes
@@ -675,6 +684,7 @@ def run(
 ) -> str:
     """Run pre-flight checks, package crates, and publish from ``workspace_root``."""
     root_path = normalise_workspace_root(workspace_root)
+    LOGGER.info("Starting publish workflow for workspace %s", root_path)
     effective_options = PublishOptions() if options is None else options
     _validate_publication_options(effective_options)
     configuration_override = configuration or effective_options.configuration
@@ -715,6 +725,7 @@ def run(
         plan, strip_patches=active_configuration.publish.strip_patches
     )
     summary_lines = _format_preparation_summary(preparation)
+    LOGGER.info("Publish workflow completed successfully for workspace %s", root_path)
     return f"{plan_message}\n\n" + "\n".join(summary_lines)
 
 

--- a/lading/commands/publish.py
+++ b/lading/commands/publish.py
@@ -538,8 +538,10 @@ def _execute_live_publication_pipeline(
     """Package and publish each crate before moving to the next crate."""
     context = _PublicationPipelineContext(plan, preparation, options, runner)
     for crate in plan.publishable:
+        LOGGER.info("Live pipeline: starting crate %s", crate.name)
         _package_crate(crate, context)
         _publish_crate(crate, context)
+        LOGGER.info("Live pipeline: completed crate %s", crate.name)
 
 
 def _ensure_configuration(
@@ -595,6 +597,7 @@ def _dispatch_publication(
 ) -> None:
     """Route to the live or dry-run publication pipeline."""
     if options.live:
+        LOGGER.info("Publication mode: live (interleaved per-crate pipeline)")
         _execute_live_publication_pipeline(
             plan,
             preparation,
@@ -602,6 +605,7 @@ def _dispatch_publication(
             runner=runner,
         )
     else:
+        LOGGER.info("Publication mode: dry-run (batched two-phase pipeline)")
         _package_publishable_crates(
             plan,
             preparation,

--- a/lading/commands/publish.py
+++ b/lading/commands/publish.py
@@ -1,5 +1,7 @@
 """Publication planning helpers for :mod:`lading.commands.publish`."""
 
+# pylint: disable=too-many-lines
+
 from __future__ import annotations
 
 import atexit
@@ -82,6 +84,16 @@ class _PublishExecutionOptions:
     live: bool
     allow_dirty: bool
     allow_unpublished_workspace_deps: bool = False
+
+
+@dc.dataclass(frozen=True, slots=True)
+class _PublicationPipelineContext:
+    """Shared inputs for cargo package and publish invocations."""
+
+    plan: PublishPlan
+    preparation: PublishPreparation
+    options: _PublishExecutionOptions
+    runner: _CommandRunner
 
 
 @dc.dataclass(frozen=True, slots=True)
@@ -397,33 +409,45 @@ def _package_publishable_crates(
     runner: _CommandRunner,
 ) -> None:
     """Package each publishable crate in order using the staged workspace."""
-    staging_root = preparation.staging_root
-    package_args: tuple[str, ...] = ("--allow-dirty",) if options.allow_dirty else ()
+    context = _PublicationPipelineContext(plan, preparation, options, runner)
     for crate in plan.publishable:
-        crate_root = _resolve_staged_crate_root(crate, plan, staging_root)
-        LOGGER.info("Running cargo package for crate %s", crate.name)
-        exit_code, stdout, stderr = runner(
-            ("cargo", "package", *package_args),
-            cwd=crate_root,
-            env=None,
+        _package_crate(crate, context)
+
+
+def _package_crate(
+    crate: WorkspaceCrate,
+    context: _PublicationPipelineContext,
+) -> None:
+    """Package one publishable crate using the staged workspace."""
+    plan = context.plan
+    options = context.options
+    package_args: tuple[str, ...] = ("--allow-dirty",) if options.allow_dirty else ()
+    crate_root = _resolve_staged_crate_root(
+        crate, plan, context.preparation.staging_root
+    )
+    LOGGER.info("Running cargo package for crate %s", crate.name)
+    exit_code, stdout, stderr = context.runner(
+        ("cargo", "package", *package_args),
+        cwd=crate_root,
+        env=None,
+    )
+    if exit_code == 0:
+        return
+    if _is_index_missing_version_error(exit_code, stdout, stderr):
+        _handle_index_missing_version(
+            _CargoInvocation(
+                crate_name=crate.name,
+                subcommand="package",
+                output=(exit_code, stdout, stderr),
+            ),
+            plan=plan,
+            options=options,
         )
-        if exit_code == 0:
-            continue
-        if _is_index_missing_version_error(exit_code, stdout, stderr):
-            _handle_index_missing_version(
-                _CargoInvocation(
-                    crate_name=crate.name,
-                    subcommand="package",
-                    output=(exit_code, stdout, stderr),
-                ),
-                plan=plan,
-                options=options,
-            )
-            continue
-        message = _format_cargo_failure_message(
-            "package", crate.name, exit_code, (stdout, stderr)
-        )
-        raise PublishPreflightError(message)
+        return
+    message = _format_cargo_failure_message(
+        "package", crate.name, exit_code, (stdout, stderr)
+    )
+    raise PublishPreflightError(message)
 
 
 _ALREADY_PUBLISHED_MARKERS: tuple[str, ...] = (
@@ -459,53 +483,79 @@ def _publish_crates(
     options: _PublishExecutionOptions,
 ) -> None:
     """Publish each crate in order, respecting dry-run vs live mode."""
-    staging_root = preparation.staging_root
+    context = _PublicationPipelineContext(plan, preparation, options, runner)
+    for crate in plan.publishable:
+        _publish_crate(crate, context)
+
+
+def _publish_crate(
+    crate: WorkspaceCrate,
+    context: _PublicationPipelineContext,
+) -> None:
+    """Publish one crate from the staged workspace."""
+    plan = context.plan
+    options = context.options
     publish_args: list[str] = []
     if options.allow_dirty:
         publish_args.append("--allow-dirty")
     if not options.live:
         publish_args.append("--dry-run")
     publish_args_tuple = tuple(publish_args)
-    for crate in plan.publishable:
-        crate_root = _resolve_staged_crate_root(crate, plan, staging_root)
-        LOGGER.info(
-            "Running cargo publish%s for crate %s",
-            "" if options.live else " --dry-run",
+    crate_root = _resolve_staged_crate_root(
+        crate, plan, context.preparation.staging_root
+    )
+    LOGGER.info(
+        "Running cargo publish%s for crate %s",
+        "" if options.live else " --dry-run",
+        crate.name,
+    )
+    exit_code, stdout, stderr = context.runner(
+        ("cargo", "publish", *publish_args_tuple),
+        cwd=crate_root,
+        env=None,
+    )
+    if exit_code == 0:
+        return
+    if _is_already_published_error(exit_code, stdout, stderr):
+        LOGGER.warning(
+            "Crate %s @ %s is already published; skipping",
             crate.name,
+            crate.version,
         )
-        exit_code, stdout, stderr = runner(
-            ("cargo", "publish", *publish_args_tuple),
-            cwd=crate_root,
-            env=None,
+        return
+    if _is_index_missing_version_error(exit_code, stdout, stderr):
+        # cargo publish --dry-run packages internally and hits the same
+        # crates.io index lookup as cargo package, so honour the override
+        # consistently across both phases.
+        _handle_index_missing_version(
+            _CargoInvocation(
+                crate_name=crate.name,
+                subcommand="publish",
+                output=(exit_code, stdout, stderr),
+            ),
+            plan=plan,
+            options=options,
         )
-        if exit_code == 0:
-            continue
-        if _is_already_published_error(exit_code, stdout, stderr):
-            LOGGER.warning(
-                "Crate %s @ %s is already published; skipping",
-                crate.name,
-                crate.version,
-            )
-            continue
-        if _is_index_missing_version_error(exit_code, stdout, stderr):
-            # cargo publish --dry-run packages internally and hits the same
-            # crates.io index lookup as cargo package, so honour the override
-            # consistently across both phases.
-            _handle_index_missing_version(
-                _CargoInvocation(
-                    crate_name=crate.name,
-                    subcommand="publish",
-                    output=(exit_code, stdout, stderr),
-                ),
-                plan=plan,
-                options=options,
-            )
-            continue
+        return
 
-        message = _format_cargo_failure_message(
-            "publish", crate.name, exit_code, (stdout, stderr)
-        )
-        raise PublishError(message)
+    message = _format_cargo_failure_message(
+        "publish", crate.name, exit_code, (stdout, stderr)
+    )
+    raise PublishError(message)
+
+
+def _execute_live_publication_pipeline(
+    plan: PublishPlan,
+    preparation: PublishPreparation,
+    *,
+    options: _PublishExecutionOptions,
+    runner: _CommandRunner,
+) -> None:
+    """Package and publish each crate before moving to the next crate."""
+    context = _PublicationPipelineContext(plan, preparation, options, runner)
+    for crate in plan.publishable:
+        _package_crate(crate, context)
+        _publish_crate(crate, context)
 
 
 def _ensure_configuration(
@@ -586,18 +636,26 @@ def run(
             effective_options.allow_unpublished_workspace_deps
         ),
     )
-    _package_publishable_crates(
-        plan,
-        preparation,
-        options=execution_options,
-        runner=command_runner,
-    )
-    _publish_crates(
-        plan,
-        preparation,
-        runner=command_runner,
-        options=execution_options,
-    )
+    if execution_options.live:
+        _execute_live_publication_pipeline(
+            plan,
+            preparation,
+            options=execution_options,
+            runner=command_runner,
+        )
+    else:
+        _package_publishable_crates(
+            plan,
+            preparation,
+            options=execution_options,
+            runner=command_runner,
+        )
+        _publish_crates(
+            plan,
+            preparation,
+            runner=command_runner,
+            options=execution_options,
+        )
     plan_message = _format_plan(
         plan, strip_patches=active_configuration.publish.strip_patches
     )

--- a/lading/commands/publish.py
+++ b/lading/commands/publish.py
@@ -126,13 +126,12 @@ class _PublishExecutionOptions:
 
 
 @dc.dataclass(frozen=True, slots=True)
-class _PublicationPipelineContext:
-    """Shared inputs for cargo package and publish invocations."""
+class _PublicationPipelineState:
+    """Shared publish state for cargo package and publish invocations."""
 
     plan: PublishPlan
     preparation: PublishPreparation
     options: _PublishExecutionOptions
-    runner: _CommandRunner
 
 
 @dc.dataclass(frozen=True, slots=True)
@@ -379,24 +378,28 @@ def _package_publishable_crates(
     runner: _CommandRunner,
 ) -> None:
     """Package each publishable crate in order using the staged workspace."""
-    context = _PublicationPipelineContext(plan, preparation, options, runner)
+    state = _PublicationPipelineState(plan, preparation, options)
     for crate in plan.publishable:
-        _package_crate(crate, context)
+        _package_crate(
+            crate,
+            state,
+            runner=runner,
+        )
 
 
 def _package_crate(
     crate: WorkspaceCrate,
-    context: _PublicationPipelineContext,
+    state: _PublicationPipelineState,
+    *,
+    runner: _CommandRunner,
 ) -> None:
     """Package one publishable crate using the staged workspace."""
-    plan = context.plan
-    options = context.options
+    plan = state.plan
+    options = state.options
     package_args: tuple[str, ...] = ("--allow-dirty",) if options.allow_dirty else ()
-    crate_root = _resolve_staged_crate_root(
-        crate, plan, context.preparation.staging_root
-    )
+    crate_root = _resolve_staged_crate_root(crate, plan, state.preparation.staging_root)
     LOGGER.info("Running cargo package for crate %s", crate.name)
-    exit_code, stdout, stderr = context.runner(
+    exit_code, stdout, stderr = runner(
         ("cargo", "package", *package_args),
         cwd=crate_root,
         env=None,
@@ -455,33 +458,37 @@ def _publish_crates(
     options: _PublishExecutionOptions,
 ) -> None:
     """Publish each crate in order, respecting dry-run vs live mode."""
-    context = _PublicationPipelineContext(plan, preparation, options, runner)
+    state = _PublicationPipelineState(plan, preparation, options)
     for crate in plan.publishable:
-        _publish_crate(crate, context)
+        _publish_crate(
+            crate,
+            state,
+            runner=runner,
+        )
 
 
 def _publish_crate(
     crate: WorkspaceCrate,
-    context: _PublicationPipelineContext,
+    state: _PublicationPipelineState,
+    *,
+    runner: _CommandRunner,
 ) -> None:
     """Publish one crate from the staged workspace."""
-    plan = context.plan
-    options = context.options
+    plan = state.plan
+    options = state.options
     publish_args: list[str] = []
     if options.allow_dirty:
         publish_args.append("--allow-dirty")
     if not options.live:
         publish_args.append("--dry-run")
     publish_args_tuple = tuple(publish_args)
-    crate_root = _resolve_staged_crate_root(
-        crate, plan, context.preparation.staging_root
-    )
+    crate_root = _resolve_staged_crate_root(crate, plan, state.preparation.staging_root)
     LOGGER.info(
         "Running cargo publish%s for crate %s",
         "" if options.live else " --dry-run",
         crate.name,
     )
-    exit_code, stdout, stderr = context.runner(
+    exit_code, stdout, stderr = runner(
         ("cargo", "publish", *publish_args_tuple),
         cwd=crate_root,
         env=None,
@@ -543,13 +550,21 @@ def _execute_live_publication_pipeline(
     runner: _CommandRunner,
 ) -> None:
     """Package and publish each crate before moving to the next crate."""
-    context = _PublicationPipelineContext(plan, preparation, options, runner)
+    state = _PublicationPipelineState(plan, preparation, options)
     completed: list[str] = []
     for crate in plan.publishable:
         LOGGER.info("Live pipeline: starting crate %s", crate.name)
         try:
-            _package_crate(crate, context)
-            _publish_crate(crate, context)
+            _package_crate(
+                crate,
+                state,
+                runner=runner,
+            )
+            _publish_crate(
+                crate,
+                state,
+                runner=runner,
+            )
         except PublishPreparationError as exc:
             # Preparation failures escape the preflight/publish error taxonomy;
             # normalise them so the live pipeline reports a single abort class.

--- a/lading/commands/publish.py
+++ b/lading/commands/publish.py
@@ -612,6 +612,7 @@ def _dispatch_publication(
             options=options,
             runner=runner,
         )
+        LOGGER.info("Dry-run pipeline: packaging complete; starting publish phase")
         _publish_crates(
             plan,
             preparation,

--- a/lading/commands/publish.py
+++ b/lading/commands/publish.py
@@ -1,21 +1,18 @@
 """Publication planning helpers for :mod:`lading.commands.publish`."""
 
-# pylint: disable=too-many-lines
-
 from __future__ import annotations
 
 import atexit
-import collections.abc as cabc
 import dataclasses as dc
 import logging
-import os
 import shutil
 import tempfile
 import typing as typ
 from pathlib import Path
 
 from lading import config as config_module
-from lading.commands.publish_diagnostics import _append_compiletest_diagnostics
+from lading.commands import publish_preflight as _publish_preflight
+from lading.commands.publish_errors import PublishError, PublishPreflightError
 from lading.commands.publish_execution import (
     _CommandRunner,
     _invoke,
@@ -58,23 +55,21 @@ _should_use_cmd_mox_stub = should_use_cmd_mox_stub
 _split_command = split_command
 _append_section = append_section
 _format_plan = format_plan
+_CargoPreflightOptions = _publish_preflight._CargoPreflightOptions
+_apply_compiletest_externs = _publish_preflight._apply_compiletest_externs
+_build_preflight_environment = _publish_preflight._build_preflight_environment
+_build_test_arguments = _publish_preflight._build_test_arguments
+_compose_preflight_arguments = _publish_preflight._compose_preflight_arguments
+_normalise_test_excludes = _publish_preflight._normalise_test_excludes
+_run_aux_build_commands = _publish_preflight._run_aux_build_commands
+_run_cargo_preflight = _publish_preflight._run_cargo_preflight
+_verify_clean_working_tree = _publish_preflight._verify_clean_working_tree
 
 LOGGER = logging.getLogger(__name__)
 
 if typ.TYPE_CHECKING:
     from lading.config import LadingConfig
     from lading.workspace import WorkspaceCrate, WorkspaceGraph
-
-
-@dc.dataclass(frozen=True, slots=True)
-class _CargoPreflightOptions:
-    """Options controlling how cargo pre-flight commands are invoked."""
-
-    extra_args: cabc.Sequence[str]
-    test_excludes: cabc.Sequence[str] = ()
-    unit_tests_only: bool = False
-    env: cabc.Mapping[str, str] | None = None
-    diagnostics_tail_lines: int | None = None
 
 
 @dc.dataclass(frozen=True, slots=True)
@@ -151,73 +146,6 @@ class PublishPreparation:
 
     staging_root: Path
     copied_readmes: tuple[Path, ...]
-
-
-class PublishPreflightError(RuntimeError):
-    """Raised when required pre-publication checks fail."""
-
-
-class PublishError(PublishPreflightError):
-    """Raised when publishing crates fails after pre-flight checks."""
-
-
-def _build_preflight_environment(
-    overrides: tuple[tuple[str, str], ...],
-) -> dict[str, str]:
-    """Return the base environment for publish pre-flight commands."""
-    env = dict(os.environ)
-    env.update(overrides)
-    return env
-
-
-def _run_aux_build_commands(
-    workspace_root: Path,
-    commands: tuple[tuple[str, ...], ...],
-    *,
-    runner: _CommandRunner,
-    env: cabc.Mapping[str, str] | None,
-) -> None:
-    """Execute auxiliary build commands prior to cargo pre-flight runs."""
-    for command in commands:
-        exit_code, stdout, stderr = runner(command, cwd=workspace_root, env=env)
-        if exit_code != 0:
-            detail = (stderr or stdout).strip()
-            rendered = " ".join(command)
-            message = (
-                f"Auxiliary build command failed with exit code {exit_code}: {rendered}"
-            )
-            if detail:
-                message = f"{message}; {detail}"
-            raise PublishPreflightError(message)
-
-
-def _resolve_extern_path(workspace_root: Path, raw_path: str) -> Path:
-    """Return ``raw_path`` resolved relative to ``workspace_root`` when needed."""
-    candidate = Path(raw_path)
-    if not candidate.is_absolute():
-        candidate = workspace_root / candidate
-    return candidate.expanduser().resolve(strict=False)
-
-
-def _apply_compiletest_externs(
-    env: cabc.Mapping[str, str],
-    externs: tuple[config_module.CompiletestExtern, ...],
-    *,
-    workspace_root: Path,
-) -> dict[str, str]:
-    """Return ``env`` with compiletest externs appended to ``RUSTFLAGS``."""
-    if not externs:
-        return dict(env)
-    updated = dict(env)
-    flags = " ".join(
-        f"--extern {extern.crate}={_resolve_extern_path(workspace_root, extern.path)}"
-        for extern in externs
-    ).strip()
-    if not flags:
-        return updated
-    previous = updated.get("RUSTFLAGS", "").strip()
-    updated["RUSTFLAGS"] = " ".join(filter(None, (previous, flags)))
-    return updated
 
 
 def _normalise_build_directory(
@@ -388,10 +316,8 @@ def _handle_index_missing_version(
 ) -> None:
     """Pick the phase-appropriate error class and delegate to the helper.
 
-    ``publish_index_check`` cannot import :class:`PublishError` /
-    :class:`PublishPreflightError` without a circular dependency, so the
-    error class is resolved here based on the cargo subcommand and passed
-    through to the relocated implementation.
+    Resolve the error class here based on the cargo subcommand and pass it
+    through to the relocated implementation in ``publish_index_check``.
     """
     error_cls = (
         PublishError if invocation.subcommand == "publish" else PublishPreflightError
@@ -514,6 +440,26 @@ def _publish_crate(
         cwd=crate_root,
         env=None,
     )
+    _handle_publish_result(
+        _CargoInvocation(
+            crate_name=crate.name,
+            subcommand="publish",
+            output=(exit_code, stdout, stderr),
+        ),
+        crate,
+        plan,
+        options,
+    )
+
+
+def _handle_publish_result(
+    invocation: _CargoInvocation,
+    crate: WorkspaceCrate,
+    plan: PublishPlan,
+    options: _PublishExecutionOptions,
+) -> None:
+    """Handle a completed ``cargo publish`` invocation."""
+    exit_code, stdout, stderr = invocation.output
     if exit_code == 0:
         return
     if _is_already_published_error(exit_code, stdout, stderr):
@@ -527,15 +473,7 @@ def _publish_crate(
         # cargo publish --dry-run packages internally and hits the same
         # crates.io index lookup as cargo package, so honour the override
         # consistently across both phases.
-        _handle_index_missing_version(
-            _CargoInvocation(
-                crate_name=crate.name,
-                subcommand="publish",
-                output=(exit_code, stdout, stderr),
-            ),
-            plan=plan,
-            options=options,
-        )
+        _handle_index_missing_version(invocation, plan=plan, options=options)
         return
 
     message = _format_cargo_failure_message(
@@ -743,17 +681,6 @@ def _run_preflight_checks(
         )
 
 
-def _compose_preflight_arguments(
-    target_dir: Path, *, include_all_targets: bool
-) -> tuple[str, ...]:
-    """Build the ordered argument tuple shared by pre-flight cargo commands."""
-    arguments = ["--workspace"]
-    if include_all_targets:
-        arguments.append("--all-targets")
-    arguments.append(f"--target-dir={target_dir}")
-    return tuple(arguments)
-
-
 def _preflight_argument_sets(
     target_dir: Path, *, unit_tests_only: bool
 ) -> tuple[tuple[str, ...], tuple[str, ...]]:
@@ -763,93 +690,3 @@ def _preflight_argument_sets(
         target_dir, include_all_targets=not unit_tests_only
     )
     return check_arguments, test_arguments
-
-
-def _normalise_test_excludes(entries: cabc.Sequence[str]) -> tuple[str, ...]:
-    """Return sorted, deduplicated, trimmed crate names for ``--exclude`` flags."""
-    return tuple(sorted({crate.strip() for crate in entries if crate.strip()}))
-
-
-def _build_test_arguments(
-    base_arguments: list[str], options: _CargoPreflightOptions
-) -> list[str]:
-    """Return cargo test arguments derived from ``options``."""
-    arguments = list(base_arguments)
-    if options.unit_tests_only:
-        arguments.extend(("--lib", "--bins"))
-    for crate_name in _normalise_test_excludes(options.test_excludes):
-        # Sorted unique values keep cargo invocations deterministic for tests/logging.
-        arguments.extend(("--exclude", crate_name))
-    return arguments
-
-
-def _verify_clean_working_tree(
-    workspace_root: Path,
-    *,
-    allow_dirty: bool,
-    runner: _CommandRunner,
-    env: cabc.Mapping[str, str] | None = None,
-) -> None:
-    """Ensure ``workspace_root`` has no uncommitted changes unless allowed."""
-    if allow_dirty:
-        return
-
-    exit_code, stdout, stderr = runner(
-        ("git", "status", "--porcelain"),
-        cwd=workspace_root,
-        env=env,
-    )
-    if exit_code != 0:
-        detail = (stderr or stdout).strip()
-        message = (
-            "Failed to verify workspace state; is this a git repository?"
-            if "not a git repository" in detail.lower()
-            else "Failed to verify workspace state with git status"
-        )
-        if detail:
-            message = f"{message}: {detail}"
-        raise PublishPreflightError(message)
-    if stdout.strip():
-        message = (
-            "Workspace has uncommitted changes; commit or stash them "
-            "before publishing or re-run without --forbid-dirty."
-        )
-        raise PublishPreflightError(message)
-
-
-def _run_cargo_preflight(
-    workspace_root: Path,
-    subcommand: typ.Literal["check", "test"],
-    *,
-    runner: _CommandRunner,
-    options: _CargoPreflightOptions,
-) -> None:
-    """Run ``cargo <subcommand>`` inside ``workspace_root``."""
-    arguments = list(options.extra_args)
-    if subcommand == "test":
-        arguments = _build_test_arguments(arguments, options)
-    exit_code, stdout, stderr = runner(
-        ("cargo", subcommand, *arguments),
-        cwd=workspace_root,
-        env=options.env,
-    )
-    if exit_code != 0:
-        message = _build_cargo_error_message(subcommand, exit_code, stdout, stderr)
-        if options.diagnostics_tail_lines is not None:
-            message = _append_compiletest_diagnostics(
-                message,
-                stdout,
-                stderr,
-                tail_lines=options.diagnostics_tail_lines,
-            )
-        raise PublishPreflightError(message)
-
-
-def _build_cargo_error_message(
-    subcommand: str, exit_code: int, stdout: str, stderr: str
-) -> str:
-    """Return a consistent failure message for cargo pre-flight commands."""
-    message = f"Pre-flight cargo {subcommand} failed with exit code {exit_code}"
-    if detail := (stderr or stdout).strip():
-        message = f"{message}: {detail}"
-    return message

--- a/lading/commands/publish.py
+++ b/lading/commands/publish.py
@@ -1,4 +1,48 @@
-"""Publication planning helpers for :mod:`lading.commands.publish`."""
+"""Orchestrate the ``lading publish`` workflow.
+
+``run()`` is the primary entry point. It loads configuration, discovers the
+workspace graph, runs pre-flight checks (:mod:`~lading.commands.publish_preflight`),
+plans publication order, stages the workspace, and dispatches to one of two
+**publish pipelines** depending on the ``live`` flag.
+
+**Pipeline dispatch**
+
+*Dry-run* (``live=False``) keeps the historical batched two-phase pipeline:
+package every publishable crate, then ``cargo publish --dry-run`` every crate
+in plan order.
+
+*Live* (``live=True``) interleaves packaging and publishing per crate via
+:func:`_execute_live_publication_pipeline`: package the next crate, publish it,
+then advance. This ordering lets dependent crates resolve newly uploaded
+in-plan dependencies during a single release train.
+
+**Per-crate helpers**
+
+:func:`_package_crate` and :func:`_publish_crate` each invoke ``cargo`` in the
+correct staged directory for a single crate. Both detect
+index-missing-version failures (:func:`_is_index_missing_version_error`) and
+publish-phase already-uploaded errors (:func:`_is_already_published_error`) to
+support non-fatal downgrade paths.
+
+**Error boundary**
+
+:class:`~lading.commands.publish_errors.PublishPreflightError` signals
+pre-publication failures (packaging, pre-flight checks).
+:class:`~lading.commands.publish_errors.PublishError` signals post-pre-flight
+publish failures and subclasses the preflight error so callers can handle all
+failures through one catch boundary or distinguish the publish phase when
+needed.
+
+**Related modules**
+
+* :mod:`lading.commands.publish_plan` — plan construction and formatting
+* :mod:`lading.commands.publish_preflight` — ``cargo check`` / ``cargo test`` /
+  git-status guards
+* :mod:`lading.commands.publish_errors` — :class:`PublishPreflightError` and
+  :class:`PublishError`
+* :mod:`lading.commands.publish_execution` — subprocess invocation and cmd-mox
+  integration
+"""
 
 from __future__ import annotations
 
@@ -358,6 +402,7 @@ def _package_crate(
         env=None,
     )
     if exit_code == 0:
+        LOGGER.info("Successfully packaged crate %s", crate.name)
         return
     if _is_index_missing_version_error(exit_code, stdout, stderr):
         _handle_index_missing_version(
@@ -461,6 +506,7 @@ def _handle_publish_result(
     """Handle a completed ``cargo publish`` invocation."""
     exit_code, stdout, stderr = invocation.output
     if exit_code == 0:
+        LOGGER.info("Successfully published crate %s", crate.name)
         return
     if _is_already_published_error(exit_code, stdout, stderr):
         LOGGER.warning(

--- a/lading/commands/publish.py
+++ b/lading/commands/publish.py
@@ -507,7 +507,12 @@ def _handle_publish_result(
     """Handle a completed ``cargo publish`` invocation."""
     exit_code, stdout, stderr = invocation.output
     if exit_code == 0:
-        LOGGER.info("Successfully published crate %s", invocation.crate_name)
+        success_message = (
+            "Successfully published crate %s"
+            if options.live
+            else "Dry-run publish succeeded for crate %s"
+        )
+        LOGGER.info(success_message, invocation.crate_name)
         return
     if _is_already_published_error(exit_code, stdout, stderr):
         LOGGER.warning(
@@ -545,6 +550,17 @@ def _execute_live_publication_pipeline(
         try:
             _package_crate(crate, context)
             _publish_crate(crate, context)
+        except PublishPreparationError as exc:
+            # Preparation failures escape the preflight/publish error taxonomy;
+            # normalise them so the live pipeline reports a single abort class.
+            LOGGER.exception(
+                "Live pipeline: aborted on crate %s — %d/%d crates completed (%s)",
+                crate.name,
+                len(completed),
+                len(plan.publishable),
+                ", ".join(completed) if completed else "none",
+            )
+            raise PublishPreflightError(str(exc)) from exc
         except (PublishPreflightError, PublishError):
             LOGGER.exception(
                 "Live pipeline: aborted on crate %s — %d/%d crates completed (%s)",

--- a/lading/commands/publish.py
+++ b/lading/commands/publish.py
@@ -587,6 +587,51 @@ def _ensure_workspace(
         raise WorkspaceModelError(message) from exc
 
 
+def _validate_publication_options(options: PublishOptions) -> None:
+    """Raise :class:`PublishPreflightError` for invalid option combinations."""
+    if options.live and options.allow_unpublished_workspace_deps:
+        message = (
+            "--allow-unpublished-workspace-deps is only valid in dry-run mode; "
+            "re-run without --live."
+        )
+        LOGGER.warning(message)
+        raise PublishPreflightError(message)
+    if options.allow_unpublished_workspace_deps:
+        LOGGER.info(
+            "Allowing unpublished workspace dependencies during dry-run publish"
+        )
+
+
+def _dispatch_publication(
+    plan: PublishPlan,
+    preparation: PublishPreparation,
+    *,
+    options: _PublishExecutionOptions,
+    runner: _CommandRunner,
+) -> None:
+    """Route to the live or dry-run publication pipeline."""
+    if options.live:
+        _execute_live_publication_pipeline(
+            plan,
+            preparation,
+            options=options,
+            runner=runner,
+        )
+    else:
+        _package_publishable_crates(
+            plan,
+            preparation,
+            options=options,
+            runner=runner,
+        )
+        _publish_crates(
+            plan,
+            preparation,
+            runner=runner,
+            options=options,
+        )
+
+
 def run(
     workspace_root: Path,
     configuration: LadingConfig | None = None,
@@ -597,17 +642,7 @@ def run(
     """Run pre-flight checks, package crates, and publish from ``workspace_root``."""
     root_path = normalise_workspace_root(workspace_root)
     effective_options = PublishOptions() if options is None else options
-    if effective_options.live and effective_options.allow_unpublished_workspace_deps:
-        message = (
-            "--allow-unpublished-workspace-deps is only valid in dry-run mode; "
-            "re-run without --live."
-        )
-        LOGGER.warning(message)
-        raise PublishPreflightError(message)
-    if effective_options.allow_unpublished_workspace_deps:
-        LOGGER.info(
-            "Allowing unpublished workspace dependencies during dry-run publish"
-        )
+    _validate_publication_options(effective_options)
     configuration_override = configuration or effective_options.configuration
     workspace_override = workspace or effective_options.workspace
     command_runner = effective_options.command_runner or _invoke
@@ -636,26 +671,12 @@ def run(
             effective_options.allow_unpublished_workspace_deps
         ),
     )
-    if execution_options.live:
-        _execute_live_publication_pipeline(
-            plan,
-            preparation,
-            options=execution_options,
-            runner=command_runner,
-        )
-    else:
-        _package_publishable_crates(
-            plan,
-            preparation,
-            options=execution_options,
-            runner=command_runner,
-        )
-        _publish_crates(
-            plan,
-            preparation,
-            runner=command_runner,
-            options=execution_options,
-        )
+    _dispatch_publication(
+        plan,
+        preparation,
+        options=execution_options,
+        runner=command_runner,
+    )
     plan_message = _format_plan(
         plan, strip_patches=active_configuration.publish.strip_patches
     )

--- a/lading/commands/publish.py
+++ b/lading/commands/publish.py
@@ -418,6 +418,7 @@ def _package_crate(
     message = _format_cargo_failure_message(
         "package", crate.name, exit_code, (stdout, stderr)
     )
+    LOGGER.error(message)
     raise PublishPreflightError(message)
 
 
@@ -525,6 +526,7 @@ def _handle_publish_result(
     message = _format_cargo_failure_message(
         "publish", crate.name, exit_code, (stdout, stderr)
     )
+    LOGGER.error(message)
     raise PublishError(message)
 
 
@@ -537,11 +539,23 @@ def _execute_live_publication_pipeline(
 ) -> None:
     """Package and publish each crate before moving to the next crate."""
     context = _PublicationPipelineContext(plan, preparation, options, runner)
+    completed: list[str] = []
     for crate in plan.publishable:
         LOGGER.info("Live pipeline: starting crate %s", crate.name)
-        _package_crate(crate, context)
-        _publish_crate(crate, context)
+        try:
+            _package_crate(crate, context)
+            _publish_crate(crate, context)
+        except (PublishPreflightError, PublishError):
+            LOGGER.exception(
+                "Live pipeline: aborted on crate %s — %d/%d crates completed (%s)",
+                crate.name,
+                len(completed),
+                len(plan.publishable),
+                ", ".join(completed) if completed else "none",
+            )
+            raise
         LOGGER.info("Live pipeline: completed crate %s", crate.name)
+        completed.append(crate.name)
 
 
 def _ensure_configuration(
@@ -580,7 +594,7 @@ def _validate_publication_options(options: PublishOptions) -> None:
             "--allow-unpublished-workspace-deps is only valid in dry-run mode; "
             "re-run without --live."
         )
-        LOGGER.warning(message)
+        LOGGER.error(message)
         raise PublishPreflightError(message)
     if options.allow_unpublished_workspace_deps:
         LOGGER.info(

--- a/lading/commands/publish_errors.py
+++ b/lading/commands/publish_errors.py
@@ -1,14 +1,73 @@
-"""Error types raised by publish command workflows."""
+"""Exception types shared by publish command workflows.
+
+``publish_errors`` defines the public error boundary for publish orchestration.
+Pre-flight components raise :class:`PublishPreflightError` when local checks
+cannot prove the workspace is ready to publish. The live and dry-run publish
+pipelines raise :class:`PublishError` when cargo publication work fails after
+those checks have completed.
+
+Both classes inherit from :class:`RuntimeError`, carry their message through the
+standard exception ``args`` tuple, and avoid additional mutable state. Callers of
+``lading.commands.publish.run`` can catch :class:`PublishPreflightError` to
+handle both validation and publish failures through one path, or catch
+:class:`PublishError` first when publish-phase failures need distinct handling.
+
+Examples
+--------
+>>> from lading.commands.publish_errors import PublishError
+>>> try:
+...     raise PublishError("cargo publish failed")
+... except PublishError as exc:
+...     str(exc)
+'cargo publish failed'
+"""
 
 from __future__ import annotations
 
 
 class PublishPreflightError(RuntimeError):
-    """Raised when required pre-publication checks fail."""
+    """Raise when required pre-publication checks fail.
+
+    Parameters
+    ----------
+    *args
+        Positional arguments passed to :class:`RuntimeError`; the first
+        argument is conventionally the human-readable failure message.
+
+    Attributes
+    ----------
+    args
+        The message arguments stored by :class:`RuntimeError`.
+
+    Notes
+    -----
+    Pre-flight helpers raise this exception before publication begins, for
+    example when the working tree is dirty, an auxiliary build command fails,
+    or a cargo check/test pre-flight command exits unsuccessfully.
+    """
 
 
 class PublishError(PublishPreflightError):
-    """Raised when publishing crates fails after pre-flight checks."""
+    """Raise when crate publishing fails after pre-flight checks.
+
+    Parameters
+    ----------
+    *args
+        Positional arguments passed to :class:`PublishPreflightError`; the first
+        argument is conventionally the human-readable cargo failure message.
+
+    Attributes
+    ----------
+    args
+        The message arguments stored by :class:`RuntimeError`.
+
+    Notes
+    -----
+    ``PublishError`` subclasses :class:`PublishPreflightError` so callers can
+    handle all publish command failures through the broader pre-flight error
+    boundary while still distinguishing failures from the cargo publish phase
+    when needed.
+    """
 
 
 __all__ = [

--- a/lading/commands/publish_errors.py
+++ b/lading/commands/publish_errors.py
@@ -1,0 +1,17 @@
+"""Error types raised by publish command workflows."""
+
+from __future__ import annotations
+
+
+class PublishPreflightError(RuntimeError):
+    """Raised when required pre-publication checks fail."""
+
+
+class PublishError(PublishPreflightError):
+    """Raised when publishing crates fails after pre-flight checks."""
+
+
+__all__ = [
+    "PublishError",
+    "PublishPreflightError",
+]

--- a/lading/commands/publish_preflight.py
+++ b/lading/commands/publish_preflight.py
@@ -1,0 +1,267 @@
+"""Pre-flight checks for publish command workflows."""
+
+from __future__ import annotations
+
+import collections.abc as cabc
+import dataclasses as dc
+import os
+import tempfile
+import typing as typ
+from pathlib import Path
+
+from lading.commands.publish_diagnostics import _append_compiletest_diagnostics
+from lading.commands.publish_errors import PublishPreflightError
+from lading.commands.publish_execution import _CommandRunner, _invoke
+
+if typ.TYPE_CHECKING:
+    from lading.config import CompiletestExtern, LadingConfig
+
+
+@dc.dataclass(frozen=True, slots=True)
+class _CargoPreflightOptions:
+    """Options controlling how cargo pre-flight commands are invoked."""
+
+    extra_args: cabc.Sequence[str]
+    test_excludes: cabc.Sequence[str] = ()
+    unit_tests_only: bool = False
+    env: cabc.Mapping[str, str] | None = None
+    diagnostics_tail_lines: int | None = None
+
+
+def _build_preflight_environment(
+    overrides: tuple[tuple[str, str], ...],
+) -> dict[str, str]:
+    """Return the base environment for publish pre-flight commands."""
+    env = dict(os.environ)
+    env.update(overrides)
+    return env
+
+
+def _run_aux_build_commands(
+    workspace_root: Path,
+    commands: tuple[tuple[str, ...], ...],
+    *,
+    runner: _CommandRunner,
+    env: cabc.Mapping[str, str] | None,
+) -> None:
+    """Execute auxiliary build commands prior to cargo pre-flight runs."""
+    for command in commands:
+        exit_code, stdout, stderr = runner(command, cwd=workspace_root, env=env)
+        if exit_code != 0:
+            detail = (stderr or stdout).strip()
+            rendered = " ".join(command)
+            message = (
+                f"Auxiliary build command failed with exit code {exit_code}: {rendered}"
+            )
+            if detail:
+                message = f"{message}; {detail}"
+            raise PublishPreflightError(message)
+
+
+def _resolve_extern_path(workspace_root: Path, raw_path: str) -> Path:
+    """Return ``raw_path`` resolved relative to ``workspace_root`` when needed."""
+    candidate = Path(raw_path)
+    if not candidate.is_absolute():
+        candidate = workspace_root / candidate
+    return candidate.expanduser().resolve(strict=False)
+
+
+def _apply_compiletest_externs(
+    env: cabc.Mapping[str, str],
+    externs: tuple[CompiletestExtern, ...],
+    *,
+    workspace_root: Path,
+) -> dict[str, str]:
+    """Return ``env`` with compiletest externs appended to ``RUSTFLAGS``."""
+    if not externs:
+        return dict(env)
+    updated = dict(env)
+    flags = " ".join(
+        f"--extern {extern.crate}={_resolve_extern_path(workspace_root, extern.path)}"
+        for extern in externs
+    ).strip()
+    if not flags:
+        return updated
+    previous = updated.get("RUSTFLAGS", "").strip()
+    updated["RUSTFLAGS"] = " ".join(filter(None, (previous, flags)))
+    return updated
+
+
+def _run_preflight_checks(
+    workspace_root: Path,
+    *,
+    allow_dirty: bool,
+    configuration: LadingConfig,
+    runner: _CommandRunner | None = None,
+) -> None:
+    """Execute publish pre-flight checks for ``workspace_root``."""
+    command_runner = runner or _invoke
+    preflight_config = configuration.preflight
+    base_env = _build_preflight_environment(preflight_config.env_overrides)
+    _verify_clean_working_tree(
+        workspace_root,
+        allow_dirty=allow_dirty,
+        runner=command_runner,
+        env=base_env,
+    )
+    _run_aux_build_commands(
+        workspace_root,
+        preflight_config.aux_build,
+        runner=command_runner,
+        env=base_env,
+    )
+
+    with tempfile.TemporaryDirectory(prefix="lading-preflight-target-") as target:
+        target_path = Path(target)
+        unit_tests_only = preflight_config.unit_tests_only
+        check_arguments, test_arguments = _preflight_argument_sets(
+            target_path, unit_tests_only=unit_tests_only
+        )
+        _run_cargo_preflight(
+            workspace_root,
+            "check",
+            runner=command_runner,
+            options=_CargoPreflightOptions(
+                extra_args=check_arguments,
+                env=base_env,
+            ),
+        )
+        test_env = _apply_compiletest_externs(
+            base_env,
+            preflight_config.compiletest_externs,
+            workspace_root=workspace_root,
+        )
+        _run_cargo_preflight(
+            workspace_root,
+            "test",
+            runner=command_runner,
+            options=_CargoPreflightOptions(
+                extra_args=test_arguments,
+                test_excludes=preflight_config.test_exclude,
+                unit_tests_only=unit_tests_only,
+                env=test_env,
+                diagnostics_tail_lines=preflight_config.stderr_tail_lines,
+            ),
+        )
+
+
+def _compose_preflight_arguments(
+    target_dir: Path, *, include_all_targets: bool
+) -> tuple[str, ...]:
+    """Build the ordered argument tuple shared by pre-flight cargo commands."""
+    arguments = ["--workspace"]
+    if include_all_targets:
+        arguments.append("--all-targets")
+    arguments.append(f"--target-dir={target_dir}")
+    return tuple(arguments)
+
+
+def _preflight_argument_sets(
+    target_dir: Path, *, unit_tests_only: bool
+) -> tuple[tuple[str, ...], tuple[str, ...]]:
+    """Return argument tuples for cargo check and cargo test pre-flight calls."""
+    check_arguments = _compose_preflight_arguments(target_dir, include_all_targets=True)
+    test_arguments = _compose_preflight_arguments(
+        target_dir, include_all_targets=not unit_tests_only
+    )
+    return check_arguments, test_arguments
+
+
+def _normalise_test_excludes(entries: cabc.Sequence[str]) -> tuple[str, ...]:
+    """Return sorted, deduplicated, trimmed crate names for ``--exclude`` flags."""
+    return tuple(sorted({crate.strip() for crate in entries if crate.strip()}))
+
+
+def _build_test_arguments(
+    base_arguments: list[str], options: _CargoPreflightOptions
+) -> list[str]:
+    """Return cargo test arguments derived from ``options``."""
+    arguments = list(base_arguments)
+    if options.unit_tests_only:
+        arguments.extend(("--lib", "--bins"))
+    for crate_name in _normalise_test_excludes(options.test_excludes):
+        # Sorted unique values keep cargo invocations deterministic for tests/logging.
+        arguments.extend(("--exclude", crate_name))
+    return arguments
+
+
+def _verify_clean_working_tree(
+    workspace_root: Path,
+    *,
+    allow_dirty: bool,
+    runner: _CommandRunner,
+    env: cabc.Mapping[str, str] | None = None,
+) -> None:
+    """Ensure ``workspace_root`` has no uncommitted changes unless allowed."""
+    if allow_dirty:
+        return
+
+    exit_code, stdout, stderr = runner(
+        ("git", "status", "--porcelain"),
+        cwd=workspace_root,
+        env=env,
+    )
+    if exit_code != 0:
+        detail = (stderr or stdout).strip()
+        message = (
+            "Failed to verify workspace state; is this a git repository?"
+            if "not a git repository" in detail.lower()
+            else "Failed to verify workspace state with git status"
+        )
+        if detail:
+            message = f"{message}: {detail}"
+        raise PublishPreflightError(message)
+    if stdout.strip():
+        message = (
+            "Workspace has uncommitted changes; commit or stash them "
+            "before publishing or re-run without --forbid-dirty."
+        )
+        raise PublishPreflightError(message)
+
+
+def _run_cargo_preflight(
+    workspace_root: Path,
+    subcommand: typ.Literal["check", "test"],
+    *,
+    runner: _CommandRunner,
+    options: _CargoPreflightOptions,
+) -> None:
+    """Run ``cargo <subcommand>`` inside ``workspace_root``."""
+    arguments = list(options.extra_args)
+    if subcommand == "test":
+        arguments = _build_test_arguments(arguments, options)
+    exit_code, stdout, stderr = runner(
+        ("cargo", subcommand, *arguments),
+        cwd=workspace_root,
+        env=options.env,
+    )
+    if exit_code != 0:
+        message = _build_cargo_error_message(subcommand, exit_code, stdout, stderr)
+        if options.diagnostics_tail_lines is not None:
+            message = _append_compiletest_diagnostics(
+                message,
+                stdout,
+                stderr,
+                tail_lines=options.diagnostics_tail_lines,
+            )
+        raise PublishPreflightError(message)
+
+
+def _build_cargo_error_message(
+    subcommand: str, exit_code: int, stdout: str, stderr: str
+) -> str:
+    """Return a consistent failure message for cargo pre-flight commands."""
+    message = f"Pre-flight cargo {subcommand} failed with exit code {exit_code}"
+    if detail := (stderr or stdout).strip():
+        message = f"{message}: {detail}"
+    return message
+
+
+__all__ = [
+    "_CargoPreflightOptions",
+    "_build_test_arguments",
+    "_compose_preflight_arguments",
+    "_run_cargo_preflight",
+    "_run_preflight_checks",
+    "_verify_clean_working_tree",
+]

--- a/lading/commands/publish_preflight.py
+++ b/lading/commands/publish_preflight.py
@@ -1,4 +1,22 @@
-"""Pre-flight checks for publish command workflows."""
+"""Pre-flight checks for publish command workflows.
+
+``publish_preflight`` contains the local validation work that runs before the
+publish pipeline packages or uploads crates. It builds the cargo environment,
+checks whether the working tree is clean, runs configured auxiliary build
+commands, and executes cargo check/test commands with the publish pre-flight
+configuration.
+
+The publish command calls :func:`_run_preflight_checks` before planning and
+dispatching publication. The function returns ``None`` when every check passes
+and raises :class:`lading.commands.publish_errors.PublishPreflightError` when a
+required check fails.
+
+Examples
+--------
+>>> from pathlib import Path
+>>> from lading.commands.publish_preflight import _run_preflight_checks
+>>> _run_preflight_checks(Path("."), allow_dirty=False, configuration=config)
+"""
 
 from __future__ import annotations
 

--- a/lading/commands/publish_preflight.py
+++ b/lading/commands/publish_preflight.py
@@ -22,6 +22,7 @@ from __future__ import annotations
 
 import collections.abc as cabc
 import dataclasses as dc
+import logging
 import os
 import tempfile
 import typing as typ
@@ -33,6 +34,9 @@ from lading.commands.publish_execution import _CommandRunner, _invoke
 
 if typ.TYPE_CHECKING:
     from lading.config import CompiletestExtern, LadingConfig
+
+
+LOGGER = logging.getLogger(__name__)
 
 
 @dc.dataclass(frozen=True, slots=True)
@@ -73,6 +77,7 @@ def _run_aux_build_commands(
             )
             if detail:
                 message = f"{message}; {detail}"
+            LOGGER.error(message)
             raise PublishPreflightError(message)
 
 
@@ -228,12 +233,14 @@ def _verify_clean_working_tree(
         )
         if detail:
             message = f"{message}: {detail}"
+        LOGGER.error(message)
         raise PublishPreflightError(message)
     if stdout.strip():
         message = (
             "Workspace has uncommitted changes; commit or stash them "
             "before publishing or re-run without --forbid-dirty."
         )
+        LOGGER.error(message)
         raise PublishPreflightError(message)
 
 
@@ -262,6 +269,7 @@ def _run_cargo_preflight(
                 stderr,
                 tail_lines=options.diagnostics_tail_lines,
             )
+        LOGGER.error(message)
         raise PublishPreflightError(message)
 
 

--- a/tests/bdd/features/cli.feature
+++ b/tests/bdd/features/cli.feature
@@ -129,6 +129,7 @@ Feature: Lading CLI scaffolding
     And cargo metadata describes a workspace with a publish dependency chain
     When I invoke lading publish with that workspace using --live
     Then the publish command performs live cargo publish for crates "alpha, beta, gamma"
+    And the publish command interleaves live package and publish for crates "alpha, beta, gamma"
 
   Scenario: Publish command continues past already published crate versions
     Given a workspace directory with configuration

--- a/tests/bdd/steps/test_publish_then_steps.py
+++ b/tests/bdd/steps/test_publish_then_steps.py
@@ -257,12 +257,15 @@ def then_publish_interleaves_live_package_and_publish(
 ) -> None:
     """Assert live publish packages and publishes each crate before the next."""
     expected_names = _split_names(crate_names)
-    observed_sequence: list[tuple[str, str]] = []
-    for label, _args, env in preflight_recorder.records:
-        if label not in {"cargo::package", "cargo::publish"}:
-            continue
-        cwd = env.get("PWD", "")
-        observed_sequence.append((label, Path(cwd).name if cwd else ""))
+    filtered = [
+        (label, (args, env))
+        for label, args, env in preflight_recorder.records
+        if label in {"cargo::package", "cargo::publish"}
+    ]
+    labels = [label for label, _ in filtered]
+    invocations = [invocation for _, invocation in filtered]
+    crate_names_observed = _extract_crate_names_from_invocations(invocations)
+    observed_sequence = list(zip(labels, crate_names_observed, strict=True))
 
     expected_sequence: list[tuple[str, str]] = []
     for crate_name in expected_names:

--- a/tests/bdd/steps/test_publish_then_steps.py
+++ b/tests/bdd/steps/test_publish_then_steps.py
@@ -1,4 +1,27 @@
-"""Then steps for publish BDD scenarios."""
+"""Then-step definitions for publish BDD scenarios.
+
+Implements :mod:`pytest_bdd` *then* steps that assert post-command
+outcomes for ``lading publish`` scenarios defined in
+``tests/bdd/features/cli.feature``.
+
+Step inventory
+--------------
+``then_publish_interleaves_live_package_and_publish(preflight_recorder, crate_names)``
+    Filters recorded invocations to ``cargo::package`` and
+    ``cargo::publish`` operations, derives the observed crate name from
+    each invocation's ``PWD`` directory basename, and asserts that the
+    sequence matches the expected interleaved order for the
+    comma-separated ``crate_names``.
+
+Related step modules
+--------------------
+``test_publish_given_steps``
+    *Given* steps that configure the workspace and publish plan.
+``test_publish_when_steps``
+    *When* steps that invoke the CLI command under test.
+``test_publish_helpers``
+    Shared assertion helpers used across given/when/then step modules.
+"""
 
 from __future__ import annotations
 

--- a/tests/bdd/steps/test_publish_then_steps.py
+++ b/tests/bdd/steps/test_publish_then_steps.py
@@ -223,6 +223,39 @@ def then_publish_runs_live(
     _assert_crate_order_matches(observed, expected, "cargo publish live order")
 
 
+@then(
+    parsers.parse(
+        "the publish command interleaves live package and publish for crates "
+        '"{crate_names}"'
+    )
+)
+def then_publish_interleaves_live_package_and_publish(
+    preflight_recorder: _PreflightInvocationRecorder, crate_names: str
+) -> None:
+    """Assert live publish packages and publishes each crate before the next."""
+    expected_names = _split_names(crate_names)
+    observed_sequence: list[tuple[str, str]] = []
+    for label, _args, env in preflight_recorder.records:
+        if label not in {"cargo::package", "cargo::publish"}:
+            continue
+        cwd = env.get("PWD", "")
+        observed_sequence.append((label, Path(cwd).name if cwd else ""))
+
+    expected_sequence: list[tuple[str, str]] = []
+    for crate_name in expected_names:
+        expected_sequence.extend([
+            ("cargo::package", crate_name),
+            ("cargo::publish", crate_name),
+        ])
+
+    if observed_sequence != expected_sequence:
+        message = (
+            "Unexpected live package/publish order: "
+            f"observed={observed_sequence!r}, expected={expected_sequence!r}"
+        )
+        raise AssertionError(message)
+
+
 @then("the publish command reports that no crates are publishable")
 def then_publish_reports_none(cli_run: dict[str, typ.Any]) -> None:
     """Assert that the publish command highlights the empty publish list."""

--- a/tests/unit/publish/__snapshots__/test_packaging.ambr
+++ b/tests/unit/publish/__snapshots__/test_packaging.ambr
@@ -1,7 +1,7 @@
 # serializer version: 1
-# name: test_package_crate_error_message_snapshot
+# name: test_crate_helper_error_message_snapshot[package]
   'cargo package failed for crate alpha with exit code 1: packaging failed'
 # ---
-# name: test_publish_crate_error_message_snapshot
+# name: test_crate_helper_error_message_snapshot[publish]
   'cargo publish failed for crate alpha with exit code 1: publish failed'
 # ---

--- a/tests/unit/publish/__snapshots__/test_packaging.ambr
+++ b/tests/unit/publish/__snapshots__/test_packaging.ambr
@@ -1,0 +1,7 @@
+# serializer version: 1
+# name: test_package_crate_error_message_snapshot
+  'cargo package failed for crate alpha with exit code 1: packaging failed'
+# ---
+# name: test_publish_crate_error_message_snapshot
+  'cargo publish failed for crate alpha with exit code 1: publish failed'
+# ---

--- a/tests/unit/publish/__snapshots__/test_snapshot_messages.ambr
+++ b/tests/unit/publish/__snapshots__/test_snapshot_messages.ambr
@@ -1,4 +1,18 @@
 # serializer version: 1
+# name: test_dry_run_pipeline_info_log_snapshot
+  tuple(
+    tuple(
+      'Publication mode: dry-run (batched two-phase pipeline)',
+      tuple(
+      ),
+    ),
+    tuple(
+      'Dry-run pipeline: packaging complete; starting publish phase',
+      tuple(
+      ),
+    ),
+  )
+# ---
 # name: test_index_missing_flag_disabled_message_snapshot[message]
   '''
   cargo package failed for crate beta with exit code 1: error: failed to prepare local package for uploading
@@ -70,6 +84,51 @@
         'package',
         'beta',
         'external_crate',
+      ),
+    ),
+  )
+# ---
+# name: test_live_pipeline_info_log_snapshot
+  tuple(
+    tuple(
+      'Publication mode: live (interleaved per-crate pipeline)',
+      tuple(
+      ),
+    ),
+    tuple(
+      'Live pipeline: starting crate %s',
+      tuple(
+        'alpha',
+      ),
+    ),
+    tuple(
+      'Live pipeline: completed crate %s',
+      tuple(
+        'alpha',
+      ),
+    ),
+    tuple(
+      'Live pipeline: starting crate %s',
+      tuple(
+        'beta',
+      ),
+    ),
+    tuple(
+      'Live pipeline: completed crate %s',
+      tuple(
+        'beta',
+      ),
+    ),
+    tuple(
+      'Live pipeline: starting crate %s',
+      tuple(
+        'gamma',
+      ),
+    ),
+    tuple(
+      'Live pipeline: completed crate %s',
+      tuple(
+        'gamma',
       ),
     ),
   )

--- a/tests/unit/publish/__snapshots__/test_snapshot_messages.ambr
+++ b/tests/unit/publish/__snapshots__/test_snapshot_messages.ambr
@@ -1,5 +1,5 @@
 # serializer version: 1
-# name: test_dry_run_pipeline_info_log_snapshot
+# name: test_pipeline_info_log_snapshot[dry_run]
   tuple(
     tuple(
       'Publication mode: dry-run (batched two-phase pipeline)',
@@ -13,7 +13,7 @@
     ),
   )
 # ---
-# name: test_index_missing_flag_disabled_message_snapshot[message]
+# name: test_index_missing_version_message_snapshot[flag_disabled][message]
   '''
   cargo package failed for crate beta with exit code 1: error: failed to prepare local package for uploading
   
@@ -24,7 +24,7 @@
     required by package `beta v0.1.0`; dependency 'alpha' is scheduled in this publish run but is not yet on crates.io. Re-run with --allow-unpublished-workspace-deps (dry-run only) or follow the staged-publish workaround in the user guide.
   '''
 # ---
-# name: test_index_missing_flag_disabled_message_snapshot[warning]
+# name: test_index_missing_version_message_snapshot[flag_disabled][warning]
   tuple(
     tuple(
       'cargo %s for crate %s failed due to unindexed sibling dependency %r (in plan); re-run with --allow-unpublished-workspace-deps to downgrade to a warning, or follow the staged-publish workaround',
@@ -48,7 +48,7 @@
     ),
   )
 # ---
-# name: test_index_missing_name_extraction_failure_message_snapshot[message]
+# name: test_index_missing_version_message_snapshot[name_extraction_failure][message]
   '''
   cargo package failed for crate beta with exit code 1: error: failed to prepare local package for uploading
   
@@ -57,7 +57,7 @@
     location searched: crates.io index
   '''
 # ---
-# name: test_index_missing_name_extraction_failure_message_snapshot[warning]
+# name: test_index_missing_version_message_snapshot[name_extraction_failure][warning]
   tuple(
     tuple(
       'cargo %s for crate %s matched index-missing-version markers but the dependency name could not be extracted; treating as fatal',
@@ -88,7 +88,7 @@
     ),
   )
 # ---
-# name: test_live_pipeline_info_log_snapshot
+# name: test_pipeline_info_log_snapshot[live]
   tuple(
     tuple(
       'Publication mode: live (interleaved per-crate pipeline)',

--- a/tests/unit/publish/test_packaging.py
+++ b/tests/unit/publish/test_packaging.py
@@ -9,6 +9,8 @@ import typing as typ
 if typ.TYPE_CHECKING:
     from pathlib import Path
 
+    from syrupy.assertion import SnapshotAssertion
+
 import pytest
 
 from lading.commands import publish
@@ -72,8 +74,11 @@ def test_package_publishable_crates_runs_in_plan_order(
     ], "cargo package should run once per publishable crate in order"
     assert caplog.messages == [
         "Running cargo package for crate alpha",
+        "Successfully packaged crate alpha",
         "Running cargo package for crate beta",
+        "Successfully packaged crate beta",
         "Running cargo package for crate gamma",
+        "Successfully packaged crate gamma",
     ]
 
 
@@ -429,3 +434,41 @@ def test_publish_crates_raise_on_failure(
     message = str(excinfo.value)
     assert "cargo publish failed for crate" in message
     assert "network offline" in message
+
+
+def test_package_crate_error_message_snapshot(
+    publish_plan_and_prep: tuple[publish.PublishPlan, publish.PublishPreparation, Path],
+    snapshot: SnapshotAssertion,
+) -> None:
+    """Snapshot the error message raised by ``_package_crate`` on failure."""
+    plan, preparation, _staging_root = publish_plan_and_prep
+    context = publish._PublicationPipelineContext(
+        plan,
+        preparation,
+        publish._PublishExecutionOptions(live=False, allow_dirty=True),
+        make_failing_runner(stdout="", stderr="packaging failed"),
+    )
+
+    with pytest.raises(publish.PublishPreflightError) as excinfo:
+        publish._package_crate(plan.publishable[0], context)
+
+    assert str(excinfo.value) == snapshot()
+
+
+def test_publish_crate_error_message_snapshot(
+    publish_plan_and_prep: tuple[publish.PublishPlan, publish.PublishPreparation, Path],
+    snapshot: SnapshotAssertion,
+) -> None:
+    """Snapshot the error message raised by ``_publish_crate`` on failure."""
+    plan, preparation, _staging_root = publish_plan_and_prep
+    context = publish._PublicationPipelineContext(
+        plan,
+        preparation,
+        publish._PublishExecutionOptions(live=True, allow_dirty=True),
+        make_failing_runner(stdout="", stderr="publish failed"),
+    )
+
+    with pytest.raises(publish.PublishError) as excinfo:
+        publish._publish_crate(plan.publishable[0], context)
+
+    assert str(excinfo.value) == snapshot()

--- a/tests/unit/publish/test_packaging.py
+++ b/tests/unit/publish/test_packaging.py
@@ -370,6 +370,47 @@ def test_execute_live_publication_pipeline_interleaves_package_and_publish(
     assert runner.calls == expected_calls
 
 
+def test_execute_live_publication_pipeline_stops_after_partial_publish(
+    publish_plan_and_prep: tuple[publish.PublishPlan, publish.PublishPreparation, Path],
+) -> None:
+    """A later live failure leaves earlier publish attempts completed."""
+    plan, preparation, staging_root = publish_plan_and_prep
+    beta_root = staging_root / plan.publishable[1].root_path.relative_to(
+        plan.workspace_root
+    )
+    calls: list[tuple[tuple[str, ...], Path | None]] = []
+
+    def runner(
+        command: cabc.Sequence[str],
+        *,
+        cwd: Path | None = None,
+        env: cabc.Mapping[str, str] | None = None,
+    ) -> tuple[int, str, str]:
+        del env
+        normalised = tuple(command)
+        calls.append((normalised, cwd))
+        if normalised[:2] == ("cargo", "package") and cwd == beta_root:
+            return 1, "", "packaging failed"
+        return 0, "", ""
+
+    with pytest.raises(publish.PublishPreflightError):
+        publish._execute_live_publication_pipeline(
+            plan,
+            preparation,
+            options=publish._PublishExecutionOptions(live=True, allow_dirty=True),
+            runner=runner,
+        )
+
+    alpha_root = staging_root / plan.publishable[0].root_path.relative_to(
+        plan.workspace_root
+    )
+    assert calls == [
+        (("cargo", "package", "--allow-dirty"), alpha_root),
+        (("cargo", "publish", "--allow-dirty"), alpha_root),
+        (("cargo", "package", "--allow-dirty"), beta_root),
+    ]
+
+
 def test_publish_crates_raise_on_failure(
     publish_plan_and_prep: tuple[publish.PublishPlan, publish.PublishPreparation, Path],
 ) -> None:

--- a/tests/unit/publish/test_packaging.py
+++ b/tests/unit/publish/test_packaging.py
@@ -436,39 +436,43 @@ def test_publish_crates_raise_on_failure(
     assert "network offline" in message
 
 
-def test_package_crate_error_message_snapshot(
+@pytest.mark.parametrize(
+    ("fn", "options", "exc_type", "stderr_text"),
+    [
+        pytest.param(
+            publish._package_crate,
+            publish._PublishExecutionOptions(live=False, allow_dirty=True),
+            publish.PublishPreflightError,
+            "packaging failed",
+            id="package",
+        ),
+        pytest.param(
+            publish._publish_crate,
+            publish._PublishExecutionOptions(live=True, allow_dirty=True),
+            publish.PublishError,
+            "publish failed",
+            id="publish",
+        ),
+    ],
+)
+def test_crate_helper_error_message_snapshot(
     publish_plan_and_prep: tuple[publish.PublishPlan, publish.PublishPreparation, Path],
     snapshot: SnapshotAssertion,
+    fn: cabc.Callable[..., None],
+    options: publish._PublishExecutionOptions,
+    exc_type: type[Exception],
+    stderr_text: str,
 ) -> None:
-    """Snapshot the error message raised by ``_package_crate`` on failure."""
+    """Snapshot the error message raised by each single-crate helper on failure."""
     plan, preparation, _staging_root = publish_plan_and_prep
     context = publish._PublicationPipelineContext(
         plan,
         preparation,
-        publish._PublishExecutionOptions(live=False, allow_dirty=True),
-        make_failing_runner(stdout="", stderr="packaging failed"),
+        options,
+        make_failing_runner(stdout="", stderr=stderr_text),
     )
 
-    with pytest.raises(publish.PublishPreflightError) as excinfo:
-        publish._package_crate(plan.publishable[0], context)
-
-    assert str(excinfo.value) == snapshot()
-
-
-def test_publish_crate_error_message_snapshot(
-    publish_plan_and_prep: tuple[publish.PublishPlan, publish.PublishPreparation, Path],
-    snapshot: SnapshotAssertion,
-) -> None:
-    """Snapshot the error message raised by ``_publish_crate`` on failure."""
-    plan, preparation, _staging_root = publish_plan_and_prep
-    context = publish._PublicationPipelineContext(
-        plan,
-        preparation,
-        publish._PublishExecutionOptions(live=True, allow_dirty=True),
-        make_failing_runner(stdout="", stderr="publish failed"),
-    )
-
-    with pytest.raises(publish.PublishError) as excinfo:
-        publish._publish_crate(plan.publishable[0], context)
+    with pytest.raises(exc_type) as excinfo:
+        fn(plan.publishable[0], context)
 
     assert str(excinfo.value) == snapshot()

--- a/tests/unit/publish/test_packaging.py
+++ b/tests/unit/publish/test_packaging.py
@@ -1,4 +1,41 @@
-"""Unit tests for publish crate packaging workflow."""
+"""Unit tests for publish crate packaging workflow.
+
+Exercises the per-crate publication helpers and the interleaved live
+pipeline introduced in :mod:`lading.commands.publish`:
+
+- :func:`~lading.commands.publish._package_crate` — packages one crate
+  from the staged workspace via ``cargo package``.
+- :func:`~lading.commands.publish._publish_crate` — publishes one crate
+  via ``cargo publish``, with ``--dry-run`` injected when not in live
+  mode.
+- :func:`~lading.commands.publish._execute_live_publication_pipeline` —
+  orchestrates the interleaved per-crate package-then-publish flow.
+
+Test helpers
+------------
+``CallTrackingRunner``
+    Records ``(command, cwd)`` pairs without executing real ``cargo``
+    subprocesses, enabling post-call assertion of both the invoked
+    command and the working directory.
+``make_failing_runner``
+    Returns a runner that yields a configurable non-zero exit code with
+    injected stdout/stderr text, used to exercise failure branches.
+``_SnapshotCase``
+    Named tuple bundling the four parametrised fields for snapshot tests
+    (helper function, execution options, expected exception type, and
+    injected stderr text), keeping the test function's argument count
+    within the four-parameter threshold.
+
+Coverage
+--------
+- Correct ``cargo`` subcommand and ``cwd`` for each single-crate helper.
+- ``PublishPreflightError`` raised on package failure with injected stderr.
+- ``PublishError`` raised on publish failure with injected stderr.
+- Already-published continuation: warning logged, no exception raised.
+- Live pipeline interleaving: package then publish per crate in plan order.
+- Live pipeline abort after a partial publish: earlier pairs complete first.
+- Exact error-message formatting locked in via syrupy snapshot assertions.
+"""
 
 from __future__ import annotations
 

--- a/tests/unit/publish/test_packaging.py
+++ b/tests/unit/publish/test_packaging.py
@@ -25,6 +25,13 @@ from .conftest import (
 )
 
 
+class _SnapshotCase(typ.NamedTuple):
+    fn: cabc.Callable[..., None]
+    options: publish._PublishExecutionOptions
+    exc_type: type[Exception]
+    stderr_text: str
+
+
 def _assert_packaging_failure_message_contains(
     plan_and_prep: tuple[publish.PublishPlan, publish.PublishPreparation],
     runner: cabc.Callable[..., tuple[int, str, str]],
@@ -437,20 +444,24 @@ def test_publish_crates_raise_on_failure(
 
 
 @pytest.mark.parametrize(
-    ("fn", "options", "exc_type", "stderr_text"),
+    "case",
     [
         pytest.param(
-            publish._package_crate,
-            publish._PublishExecutionOptions(live=False, allow_dirty=True),
-            publish.PublishPreflightError,
-            "packaging failed",
+            _SnapshotCase(
+                fn=publish._package_crate,
+                options=publish._PublishExecutionOptions(live=False, allow_dirty=True),
+                exc_type=publish.PublishPreflightError,
+                stderr_text="packaging failed",
+            ),
             id="package",
         ),
         pytest.param(
-            publish._publish_crate,
-            publish._PublishExecutionOptions(live=True, allow_dirty=True),
-            publish.PublishError,
-            "publish failed",
+            _SnapshotCase(
+                fn=publish._publish_crate,
+                options=publish._PublishExecutionOptions(live=True, allow_dirty=True),
+                exc_type=publish.PublishError,
+                stderr_text="publish failed",
+            ),
             id="publish",
         ),
     ],
@@ -458,21 +469,18 @@ def test_publish_crates_raise_on_failure(
 def test_crate_helper_error_message_snapshot(
     publish_plan_and_prep: tuple[publish.PublishPlan, publish.PublishPreparation, Path],
     snapshot: SnapshotAssertion,
-    fn: cabc.Callable[..., None],
-    options: publish._PublishExecutionOptions,
-    exc_type: type[Exception],
-    stderr_text: str,
+    case: _SnapshotCase,
 ) -> None:
     """Snapshot the error message raised by each single-crate helper on failure."""
     plan, preparation, _staging_root = publish_plan_and_prep
     context = publish._PublicationPipelineContext(
         plan,
         preparation,
-        options,
-        make_failing_runner(stdout="", stderr=stderr_text),
+        case.options,
+        make_failing_runner(stdout="", stderr=case.stderr_text),
     )
 
-    with pytest.raises(exc_type) as excinfo:
-        fn(plan.publishable[0], context)
+    with pytest.raises(case.exc_type) as excinfo:
+        case.fn(plan.publishable[0], context)
 
     assert str(excinfo.value) == snapshot()

--- a/tests/unit/publish/test_packaging.py
+++ b/tests/unit/publish/test_packaging.py
@@ -30,7 +30,7 @@ Coverage
 --------
 - Correct ``cargo`` subcommand and ``cwd`` for each single-crate helper.
 - ``PublishPreflightError`` raised on package failure with injected stderr.
-- ``PublishError`` raised on publish failure with injected stderr.
+- ``PublishError`` raised on publish failure with injected stdout.
 - Already-published continuation: warning logged, no exception raised.
 - Live pipeline interleaving: package then publish per crate in plan order.
 - Live pipeline abort after a partial publish: earlier pairs complete first.
@@ -68,6 +68,15 @@ class _SnapshotCase(typ.NamedTuple):
     options: publish._PublishExecutionOptions
     exc_type: type[Exception]
     stderr_text: str
+
+
+class _FailureCase(typ.NamedTuple):
+    fn: typ.Callable[..., None]
+    live: bool
+    exc_type: type[Exception]
+    runner_kwargs: dict[str, str]
+    subcommand: str
+    output_fragment: str
 
 
 def _assert_packaging_failure_message_contains(
@@ -166,27 +175,55 @@ def test_single_crate_helper_invokes_correct_cargo_command(
     assert runner.calls == [(expected_cmd, expected_root)]
 
 
-def test_package_crate_raises_on_failure(
+@pytest.mark.parametrize(
+    "case",
+    [
+        pytest.param(
+            _FailureCase(
+                fn=publish._package_crate,
+                live=False,
+                exc_type=publish.PublishPreflightError,
+                runner_kwargs={"stderr": "packaging failed"},
+                subcommand="package",
+                output_fragment="packaging failed",
+            ),
+            id="package",
+        ),
+        pytest.param(
+            _FailureCase(
+                fn=publish._publish_crate,
+                live=True,
+                exc_type=publish.PublishError,
+                runner_kwargs={"stdout": "network offline"},
+                subcommand="publish",
+                output_fragment="network offline",
+            ),
+            id="publish",
+        ),
+    ],
+)
+def test_crate_helper_raises_on_failure(
     publish_plan_and_prep: tuple[publish.PublishPlan, publish.PublishPreparation, Path],
+    case: _FailureCase,
 ) -> None:
-    """The single-crate packaging helper preserves package failure handling."""
+    """Each single-crate helper raises the correct exception type on failure."""
     plan, preparation, _staging_root = publish_plan_and_prep
-    failing_runner = make_failing_runner(stderr="packaging failed")
     state = publish._PublicationPipelineState(
         plan,
         preparation,
-        publish._PublishExecutionOptions(live=False, allow_dirty=True),
+        publish._PublishExecutionOptions(live=case.live, allow_dirty=True),
     )
 
-    with pytest.raises(publish.PublishPreflightError) as excinfo:
-        publish._package_crate(
+    with pytest.raises(case.exc_type) as excinfo:
+        case.fn(
             plan.publishable[0],
             state,
-            runner=failing_runner,
+            runner=make_failing_runner(**case.runner_kwargs),
         )
 
-    assert "cargo package failed for crate alpha" in str(excinfo.value)
-    assert "packaging failed" in str(excinfo.value)
+    message = str(excinfo.value)
+    assert f"cargo {case.subcommand} failed for crate alpha" in message
+    assert case.output_fragment in message
 
 
 def test_package_publishable_crates_stops_on_failure(
@@ -328,29 +365,6 @@ def test_publish_crate_continues_when_version_already_uploaded(
     )
 
     assert any("already published" in message for message in caplog.messages)
-
-
-def test_publish_crate_raises_on_failure(
-    publish_plan_and_prep: tuple[publish.PublishPlan, publish.PublishPreparation, Path],
-) -> None:
-    """The single-crate publish helper preserves publish failure handling."""
-    plan, preparation, _staging_root = publish_plan_and_prep
-    state = publish._PublicationPipelineState(
-        plan,
-        preparation,
-        publish._PublishExecutionOptions(live=True, allow_dirty=True),
-    )
-
-    with pytest.raises(publish.PublishError) as excinfo:
-        publish._publish_crate(
-            plan.publishable[0],
-            state,
-            runner=make_failing_runner(stdout="network offline"),
-        )
-
-    message = str(excinfo.value)
-    assert "cargo publish failed for crate alpha" in message
-    assert "network offline" in message
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/publish/test_packaging.py
+++ b/tests/unit/publish/test_packaging.py
@@ -486,6 +486,13 @@ def test_execute_live_publication_pipeline_wraps_preparation_errors(
 
     assert isinstance(excinfo.value.__cause__, publish.PublishPreparationError)
     assert str(beta_root) in str(excinfo.value)
+    alpha_root = staging_root / plan.publishable[0].root_path.relative_to(
+        plan.workspace_root
+    )
+    assert runner.calls == [
+        (("cargo", "package", "--allow-dirty"), alpha_root),
+        (("cargo", "publish", "--allow-dirty"), alpha_root),
+    ]
     assert any(
         "Live pipeline: aborted on crate beta" in message for message in caplog.messages
     )

--- a/tests/unit/publish/test_packaging.py
+++ b/tests/unit/publish/test_packaging.py
@@ -222,8 +222,13 @@ def test_crate_helper_raises_on_failure(
         )
 
     message = str(excinfo.value)
-    assert f"cargo {case.subcommand} failed for crate alpha" in message
-    assert case.output_fragment in message
+    assert f"cargo {case.subcommand} failed for crate alpha" in message, (
+        f"expected failure message to include cargo {case.subcommand} "
+        "context for crate alpha"
+    )
+    assert case.output_fragment in message, (
+        f"expected failure message to include output fragment {case.output_fragment!r}"
+    )
 
 
 def test_package_publishable_crates_stops_on_failure(

--- a/tests/unit/publish/test_packaging.py
+++ b/tests/unit/publish/test_packaging.py
@@ -41,6 +41,7 @@ from __future__ import annotations
 
 import collections.abc as cabc
 import logging
+import shutil
 import typing as typ
 
 if typ.TYPE_CHECKING:
@@ -458,6 +459,36 @@ def test_execute_live_publication_pipeline_stops_after_partial_publish(
         (("cargo", "publish", "--allow-dirty"), alpha_root),
         (("cargo", "package", "--allow-dirty"), beta_root),
     ]
+
+
+def test_execute_live_publication_pipeline_wraps_preparation_errors(
+    publish_plan_and_prep: tuple[publish.PublishPlan, publish.PublishPreparation, Path],
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Preparation failures surface as ``PublishPreflightError`` for the caller."""
+    caplog.set_level(logging.ERROR, logger="lading.commands.publish")
+    plan, preparation, staging_root = publish_plan_and_prep
+    # Remove the staged tree for the second crate so resolving its root fails
+    # mid-pipeline, after the first crate has packaged and published cleanly.
+    beta_root = staging_root / plan.publishable[1].root_path.relative_to(
+        plan.workspace_root
+    )
+    shutil.rmtree(beta_root)
+    runner = CallTrackingRunner()
+
+    with pytest.raises(publish.PublishPreflightError) as excinfo:
+        publish._execute_live_publication_pipeline(
+            plan,
+            preparation,
+            options=publish._PublishExecutionOptions(live=True, allow_dirty=True),
+            runner=runner,
+        )
+
+    assert isinstance(excinfo.value.__cause__, publish.PublishPreparationError)
+    assert str(beta_root) in str(excinfo.value)
+    assert any(
+        "Live pipeline: aborted on crate beta" in message for message in caplog.messages
+    )
 
 
 def test_publish_crates_raise_on_failure(

--- a/tests/unit/publish/test_packaging.py
+++ b/tests/unit/publish/test_packaging.py
@@ -154,14 +154,13 @@ def test_single_crate_helper_invokes_correct_cargo_command(
     plan, preparation, staging_root = publish_plan_and_prep
     runner = CallTrackingRunner()
     crate = plan.publishable[1]
-    context = publish._PublicationPipelineContext(
-        plan,
-        preparation,
-        options,
-        runner,
-    )
+    state = publish._PublicationPipelineState(plan, preparation, options)
 
-    fn(crate, context)
+    fn(
+        crate,
+        state,
+        runner=runner,
+    )
 
     expected_root = staging_root / crate.root_path.relative_to(plan.workspace_root)
     assert runner.calls == [(expected_cmd, expected_root)]
@@ -173,15 +172,18 @@ def test_package_crate_raises_on_failure(
     """The single-crate packaging helper preserves package failure handling."""
     plan, preparation, _staging_root = publish_plan_and_prep
     failing_runner = make_failing_runner(stderr="packaging failed")
-    context = publish._PublicationPipelineContext(
+    state = publish._PublicationPipelineState(
         plan,
         preparation,
         publish._PublishExecutionOptions(live=False, allow_dirty=True),
-        failing_runner,
     )
 
     with pytest.raises(publish.PublishPreflightError) as excinfo:
-        publish._package_crate(plan.publishable[0], context)
+        publish._package_crate(
+            plan.publishable[0],
+            state,
+            runner=failing_runner,
+        )
 
     assert "cargo package failed for crate alpha" in str(excinfo.value)
     assert "packaging failed" in str(excinfo.value)
@@ -313,14 +315,17 @@ def test_publish_crate_continues_when_version_already_uploaded(
         del command, cwd, env
         return 101, "", "error: crate version `alpha v0.1.0` is already uploaded"
 
-    context = publish._PublicationPipelineContext(
+    state = publish._PublicationPipelineState(
         plan,
         preparation,
         publish._PublishExecutionOptions(live=True, allow_dirty=True),
-        already_uploaded_runner,
     )
 
-    publish._publish_crate(plan.publishable[0], context)
+    publish._publish_crate(
+        plan.publishable[0],
+        state,
+        runner=already_uploaded_runner,
+    )
 
     assert any("already published" in message for message in caplog.messages)
 
@@ -330,15 +335,18 @@ def test_publish_crate_raises_on_failure(
 ) -> None:
     """The single-crate publish helper preserves publish failure handling."""
     plan, preparation, _staging_root = publish_plan_and_prep
-    context = publish._PublicationPipelineContext(
+    state = publish._PublicationPipelineState(
         plan,
         preparation,
         publish._PublishExecutionOptions(live=True, allow_dirty=True),
-        make_failing_runner(stdout="network offline"),
     )
 
     with pytest.raises(publish.PublishError) as excinfo:
-        publish._publish_crate(plan.publishable[0], context)
+        publish._publish_crate(
+            plan.publishable[0],
+            state,
+            runner=make_failing_runner(stdout="network offline"),
+        )
 
     message = str(excinfo.value)
     assert "cargo publish failed for crate alpha" in message
@@ -552,14 +560,13 @@ def test_crate_helper_error_message_snapshot(
 ) -> None:
     """Snapshot the error message raised by each single-crate helper on failure."""
     plan, preparation, _staging_root = publish_plan_and_prep
-    context = publish._PublicationPipelineContext(
-        plan,
-        preparation,
-        case.options,
-        make_failing_runner(stdout="", stderr=case.stderr_text),
-    )
+    state = publish._PublicationPipelineState(plan, preparation, case.options)
 
     with pytest.raises(case.exc_type) as excinfo:
-        case.fn(plan.publishable[0], context)
+        case.fn(
+            plan.publishable[0],
+            state,
+            runner=make_failing_runner(stdout="", stderr=case.stderr_text),
+        )
 
     assert str(excinfo.value) == snapshot()

--- a/tests/unit/publish/test_packaging.py
+++ b/tests/unit/publish/test_packaging.py
@@ -71,7 +71,7 @@ class _SnapshotCase(typ.NamedTuple):
 
 
 class _FailureCase(typ.NamedTuple):
-    fn: typ.Callable[..., None]
+    fn: cabc.Callable[..., None]
     live: bool
     exc_type: type[Exception]
     runner_kwargs: dict[str, str]

--- a/tests/unit/publish/test_packaging.py
+++ b/tests/unit/publish/test_packaging.py
@@ -2,11 +2,11 @@
 
 from __future__ import annotations
 
+import collections.abc as cabc
 import logging
 import typing as typ
 
 if typ.TYPE_CHECKING:
-    import collections.abc as cabc
     from pathlib import Path
 
 import pytest
@@ -77,24 +77,44 @@ def test_package_publishable_crates_runs_in_plan_order(
     ]
 
 
-def test_package_crate_runs_cargo_package_for_single_crate(
+@pytest.mark.parametrize(
+    ("fn", "live", "expected_cmd"),
+    [
+        pytest.param(
+            publish._package_crate,
+            False,
+            ("cargo", "package", "--allow-dirty"),
+            id="package",
+        ),
+        pytest.param(
+            publish._publish_crate,
+            True,
+            ("cargo", "publish", "--allow-dirty"),
+            id="publish",
+        ),
+    ],
+)
+def test_single_crate_helper_invokes_correct_cargo_command(
     publish_plan_and_prep: tuple[publish.PublishPlan, publish.PublishPreparation, Path],
+    fn: cabc.Callable[..., None],
+    live: bool,
+    expected_cmd: tuple[str, ...],
 ) -> None:
-    """The single-crate packaging helper invokes cargo package."""
+    """Each single-crate helper invokes the correct cargo subcommand."""
     plan, preparation, staging_root = publish_plan_and_prep
     runner = CallTrackingRunner()
     crate = plan.publishable[1]
     context = publish._PublicationPipelineContext(
         plan,
         preparation,
-        publish._PublishExecutionOptions(live=False, allow_dirty=True),
+        publish._PublishExecutionOptions(live=live, allow_dirty=True),
         runner,
     )
 
-    publish._package_crate(crate, context)
+    fn(crate, context)
 
     expected_root = staging_root / crate.root_path.relative_to(plan.workspace_root)
-    assert runner.calls == [(("cargo", "package", "--allow-dirty"), expected_root)]
+    assert runner.calls == [(expected_cmd, expected_root)]
 
 
 def test_package_crate_raises_on_failure(
@@ -224,26 +244,6 @@ def test_publish_crates_run_live_without_dry_run(
     assert runner.calls == [
         (("cargo", "publish", "--allow-dirty"), root) for root in expected_roots
     ]
-
-
-def test_publish_crate_runs_cargo_publish_for_single_crate(
-    publish_plan_and_prep: tuple[publish.PublishPlan, publish.PublishPreparation, Path],
-) -> None:
-    """The single-crate publish helper invokes cargo publish."""
-    plan, preparation, staging_root = publish_plan_and_prep
-    runner = CallTrackingRunner()
-    crate = plan.publishable[1]
-    context = publish._PublicationPipelineContext(
-        plan,
-        preparation,
-        publish._PublishExecutionOptions(live=True, allow_dirty=True),
-        runner,
-    )
-
-    publish._publish_crate(crate, context)
-
-    expected_root = staging_root / crate.root_path.relative_to(plan.workspace_root)
-    assert runner.calls == [(("cargo", "publish", "--allow-dirty"), expected_root)]
 
 
 def test_publish_crate_continues_when_version_already_uploaded(

--- a/tests/unit/publish/test_packaging.py
+++ b/tests/unit/publish/test_packaging.py
@@ -78,17 +78,17 @@ def test_package_publishable_crates_runs_in_plan_order(
 
 
 @pytest.mark.parametrize(
-    ("fn", "live", "expected_cmd"),
+    ("fn", "options", "expected_cmd"),
     [
         pytest.param(
             publish._package_crate,
-            False,
+            publish._PublishExecutionOptions(live=False, allow_dirty=True),
             ("cargo", "package", "--allow-dirty"),
             id="package",
         ),
         pytest.param(
             publish._publish_crate,
-            True,
+            publish._PublishExecutionOptions(live=True, allow_dirty=True),
             ("cargo", "publish", "--allow-dirty"),
             id="publish",
         ),
@@ -97,7 +97,7 @@ def test_package_publishable_crates_runs_in_plan_order(
 def test_single_crate_helper_invokes_correct_cargo_command(
     publish_plan_and_prep: tuple[publish.PublishPlan, publish.PublishPreparation, Path],
     fn: cabc.Callable[..., None],
-    live: bool,
+    options: publish._PublishExecutionOptions,
     expected_cmd: tuple[str, ...],
 ) -> None:
     """Each single-crate helper invokes the correct cargo subcommand."""
@@ -107,7 +107,7 @@ def test_single_crate_helper_invokes_correct_cargo_command(
     context = publish._PublicationPipelineContext(
         plan,
         preparation,
-        publish._PublishExecutionOptions(live=live, allow_dirty=True),
+        options,
         runner,
     )
 

--- a/tests/unit/publish/test_packaging.py
+++ b/tests/unit/publish/test_packaging.py
@@ -77,6 +77,46 @@ def test_package_publishable_crates_runs_in_plan_order(
     ]
 
 
+def test_package_crate_runs_cargo_package_for_single_crate(
+    publish_plan_and_prep: tuple[publish.PublishPlan, publish.PublishPreparation, Path],
+) -> None:
+    """The single-crate packaging helper invokes cargo package."""
+    plan, preparation, staging_root = publish_plan_and_prep
+    runner = CallTrackingRunner()
+    crate = plan.publishable[1]
+    context = publish._PublicationPipelineContext(
+        plan,
+        preparation,
+        publish._PublishExecutionOptions(live=False, allow_dirty=True),
+        runner,
+    )
+
+    publish._package_crate(crate, context)
+
+    expected_root = staging_root / crate.root_path.relative_to(plan.workspace_root)
+    assert runner.calls == [(("cargo", "package", "--allow-dirty"), expected_root)]
+
+
+def test_package_crate_raises_on_failure(
+    publish_plan_and_prep: tuple[publish.PublishPlan, publish.PublishPreparation, Path],
+) -> None:
+    """The single-crate packaging helper preserves package failure handling."""
+    plan, preparation, _staging_root = publish_plan_and_prep
+    failing_runner = make_failing_runner(stderr="packaging failed")
+    context = publish._PublicationPipelineContext(
+        plan,
+        preparation,
+        publish._PublishExecutionOptions(live=False, allow_dirty=True),
+        failing_runner,
+    )
+
+    with pytest.raises(publish.PublishPreflightError) as excinfo:
+        publish._package_crate(plan.publishable[0], context)
+
+    assert "cargo package failed for crate alpha" in str(excinfo.value)
+    assert "packaging failed" in str(excinfo.value)
+
+
 def test_package_publishable_crates_stops_on_failure(
     publish_plan_and_prep: tuple[publish.PublishPlan, publish.PublishPreparation, Path],
 ) -> None:
@@ -186,6 +226,75 @@ def test_publish_crates_run_live_without_dry_run(
     ]
 
 
+def test_publish_crate_runs_cargo_publish_for_single_crate(
+    publish_plan_and_prep: tuple[publish.PublishPlan, publish.PublishPreparation, Path],
+) -> None:
+    """The single-crate publish helper invokes cargo publish."""
+    plan, preparation, staging_root = publish_plan_and_prep
+    runner = CallTrackingRunner()
+    crate = plan.publishable[1]
+    context = publish._PublicationPipelineContext(
+        plan,
+        preparation,
+        publish._PublishExecutionOptions(live=True, allow_dirty=True),
+        runner,
+    )
+
+    publish._publish_crate(crate, context)
+
+    expected_root = staging_root / crate.root_path.relative_to(plan.workspace_root)
+    assert runner.calls == [(("cargo", "publish", "--allow-dirty"), expected_root)]
+
+
+def test_publish_crate_continues_when_version_already_uploaded(
+    publish_plan_and_prep: tuple[publish.PublishPlan, publish.PublishPreparation, Path],
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """The single-crate publish helper keeps already-published handling."""
+    caplog.set_level(logging.WARNING, logger="lading.commands.publish")
+    plan, preparation, _staging_root = publish_plan_and_prep
+
+    def already_uploaded_runner(
+        command: cabc.Sequence[str],
+        *,
+        cwd: Path | None = None,
+        env: cabc.Mapping[str, str] | None = None,
+    ) -> tuple[int, str, str]:
+        del command, cwd, env
+        return 101, "", "error: crate version `alpha v0.1.0` is already uploaded"
+
+    context = publish._PublicationPipelineContext(
+        plan,
+        preparation,
+        publish._PublishExecutionOptions(live=True, allow_dirty=True),
+        already_uploaded_runner,
+    )
+
+    publish._publish_crate(plan.publishable[0], context)
+
+    assert any("already published" in message for message in caplog.messages)
+
+
+def test_publish_crate_raises_on_failure(
+    publish_plan_and_prep: tuple[publish.PublishPlan, publish.PublishPreparation, Path],
+) -> None:
+    """The single-crate publish helper preserves publish failure handling."""
+    plan, preparation, _staging_root = publish_plan_and_prep
+    context = publish._PublicationPipelineContext(
+        plan,
+        preparation,
+        publish._PublishExecutionOptions(live=True, allow_dirty=True),
+        make_failing_runner(stdout="network offline"),
+    )
+
+    with pytest.raises(publish.PublishError) as excinfo:
+        publish._publish_crate(plan.publishable[0], context)
+
+    message = str(excinfo.value)
+    assert "cargo publish failed for crate alpha" in message
+    assert "network offline" in message
+
+
 @pytest.mark.parametrize(
     "live",
     [pytest.param(False, id="dry-run"), pytest.param(True, id="live")],
@@ -234,6 +343,31 @@ def test_publish_crates_continue_when_version_already_uploaded(
 
     assert calls == ["alpha", "beta"]
     assert any("already published" in message for message in caplog.messages)
+
+
+def test_execute_live_publication_pipeline_interleaves_package_and_publish(
+    publish_plan_and_prep: tuple[publish.PublishPlan, publish.PublishPreparation, Path],
+) -> None:
+    """Live publication packages and publishes each crate before continuing."""
+    plan, preparation, staging_root = publish_plan_and_prep
+    runner = CallTrackingRunner()
+
+    publish._execute_live_publication_pipeline(
+        plan,
+        preparation,
+        options=publish._PublishExecutionOptions(live=True, allow_dirty=True),
+        runner=runner,
+    )
+
+    expected_calls: list[tuple[tuple[str, ...], Path]] = []
+    for crate in plan.publishable:
+        crate_root = staging_root / crate.root_path.relative_to(plan.workspace_root)
+        expected_calls.extend([
+            (("cargo", "package", "--allow-dirty"), crate_root),
+            (("cargo", "publish", "--allow-dirty"), crate_root),
+        ])
+
+    assert runner.calls == expected_calls
 
 
 def test_publish_crates_raise_on_failure(

--- a/tests/unit/publish/test_packaging.py
+++ b/tests/unit/publish/test_packaging.py
@@ -492,7 +492,11 @@ def test_execute_live_publication_pipeline_wraps_preparation_errors(
     assert runner.calls == [
         (("cargo", "package", "--allow-dirty"), alpha_root),
         (("cargo", "publish", "--allow-dirty"), alpha_root),
-    ]
+    ], (
+        "expected alpha to be packaged and published "
+        "(cargo package + cargo publish) in alpha_root before beta "
+        f"preparation aborted; alpha_root={alpha_root!s}, calls={runner.calls!r}"
+    )
     assert any(
         "Live pipeline: aborted on crate beta" in message for message in caplog.messages
     )

--- a/tests/unit/publish/test_run_integration.py
+++ b/tests/unit/publish/test_run_integration.py
@@ -207,6 +207,35 @@ def test_run_keeps_dry_run_publication_batched(tmp_path: Path) -> None:
     )
 
 
+def test_run_keeps_live_publication_interleaved(tmp_path: Path) -> None:
+    """Live publish packages and publishes each crate before advancing."""
+    root = tmp_path / "workspace"
+    workspace = make_workspace(root, *make_dependency_chain(root))
+    configuration = make_config()
+    runner = CallTrackingRunner()
+
+    publish.run(
+        root,
+        configuration,
+        workspace,
+        options=publish.PublishOptions(
+            build_directory=tmp_path / "build",
+            command_runner=runner,
+            live=True,
+        ),
+    )
+
+    commands = [command for command, _cwd in runner.calls]
+    assert commands == [
+        command
+        for _crate in workspace.crates
+        for command in (
+            ("cargo", "package", "--allow-dirty"),
+            ("cargo", "publish", "--allow-dirty"),
+        )
+    ]
+
+
 def _make_beta_package_index_failure_runner() -> cabc.Callable[
     [cabc.Sequence[str]], tuple[int, str, str]
 ]:

--- a/tests/unit/publish/test_run_integration.py
+++ b/tests/unit/publish/test_run_integration.py
@@ -178,7 +178,11 @@ def test_run_logs_when_unpublished_workspace_dependency_override_is_enabled(
 
 
 def test_run_keeps_dry_run_publication_batched(tmp_path: Path) -> None:
-    """Dry-run publish still packages all crates before publish dry-runs."""
+    """Dry-run publish still packages all crates before publish dry-runs.
+
+    Assert full ``(command, cwd)`` pairs to confirm each crate operation
+    runs in the correct staging directory.
+    """
     root = tmp_path / "workspace"
     workspace = make_workspace(root, *make_dependency_chain(root))
     configuration = make_config()
@@ -195,16 +199,21 @@ def test_run_keeps_dry_run_publication_batched(tmp_path: Path) -> None:
         ),
     )
 
-    publishable_count = len(workspace.crates)
-    commands = [command for command, _cwd in runner.calls]
-    assert (
-        commands[:publishable_count]
-        == [("cargo", "package", "--allow-dirty")] * publishable_count
-    )
-    assert (
-        commands[publishable_count:]
-        == [("cargo", "publish", "--allow-dirty", "--dry-run")] * publishable_count
-    )
+    staging_root = (tmp_path / "build") / root.name
+    expected_crate_roots = [
+        staging_root / crate.root_path.relative_to(root) for crate in workspace.crates
+    ]
+    expected_pairs = [
+        *(
+            (("cargo", "package", "--allow-dirty"), root)
+            for root in expected_crate_roots
+        ),
+        *(
+            (("cargo", "publish", "--allow-dirty", "--dry-run"), root)
+            for root in expected_crate_roots
+        ),
+    ]
+    assert runner.calls == expected_pairs
 
 
 def test_run_keeps_live_publication_interleaved(tmp_path: Path) -> None:

--- a/tests/unit/publish/test_run_integration.py
+++ b/tests/unit/publish/test_run_integration.py
@@ -225,15 +225,16 @@ def test_run_keeps_live_publication_interleaved(tmp_path: Path) -> None:
         ),
     )
 
-    commands = [command for command, _cwd in runner.calls]
-    assert commands == [
-        command
-        for _crate in workspace.crates
+    staging_root = (tmp_path / "build") / root.name
+    expected_pairs = [
+        (command, staging_root / crate.root_path.relative_to(root))
+        for crate in workspace.crates
         for command in (
             ("cargo", "package", "--allow-dirty"),
             ("cargo", "publish", "--allow-dirty"),
         )
     ]
+    assert runner.calls == expected_pairs
 
 
 def _make_beta_package_index_failure_runner() -> cabc.Callable[

--- a/tests/unit/publish/test_run_integration.py
+++ b/tests/unit/publish/test_run_integration.py
@@ -236,12 +236,15 @@ def test_run_logs_when_unpublished_workspace_dependency_override_is_enabled(
     )
 
 
-def test_run_keeps_dry_run_publication_batched(tmp_path: Path) -> None:
+def test_run_keeps_dry_run_publication_batched(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
     """Dry-run publish still packages all crates before publish dry-runs.
 
     Assert full ``(command, cwd)`` pairs to confirm each crate operation
     runs in the correct staging directory.
     """
+    caplog.set_level(logging.INFO, logger="lading.commands.publish")
     root = tmp_path / "workspace"
     workspace = make_workspace(root, *make_dependency_chain(root))
     configuration = make_config()
@@ -274,6 +277,20 @@ def test_run_keeps_dry_run_publication_batched(tmp_path: Path) -> None:
         for crate in workspace.crates
     ]
     assert runner.calls == expected_packages + expected_dry_runs
+    assert f"Starting publish workflow for workspace {root}" in caplog.messages
+    assert any(
+        message.startswith("Preparing staged workspace for publication under ")
+        for message in caplog.messages
+    )
+    assert any(
+        message.startswith("Staged workspace created at ")
+        for message in caplog.messages
+    )
+    assert "Workspace README staging complete: 0 files copied" in caplog.messages
+    assert (
+        f"Publish workflow completed successfully for workspace {root}"
+        in caplog.messages
+    )
 
 
 def test_run_keeps_live_publication_interleaved(tmp_path: Path) -> None:

--- a/tests/unit/publish/test_run_integration.py
+++ b/tests/unit/publish/test_run_integration.py
@@ -15,6 +15,7 @@ from lading.workspace import WorkspaceGraph, WorkspaceModelError
 from .conftest import (
     INDEX_MISSING_STDERR_BETA,
     ORIGINAL_PREFLIGHT,
+    CallTrackingRunner,
     make_config,
     make_crate,
     make_dependency_chain,
@@ -173,6 +174,36 @@ def test_run_logs_when_unpublished_workspace_dependency_override_is_enabled(
         in message
         and "continuing because --allow-unpublished-workspace-deps is set" in message
         for message in caplog.messages
+    )
+
+
+def test_run_keeps_dry_run_publication_batched(tmp_path: Path) -> None:
+    """Dry-run publish still packages all crates before publish dry-runs."""
+    root = tmp_path / "workspace"
+    workspace = make_workspace(root, *make_dependency_chain(root))
+    configuration = make_config()
+    runner = CallTrackingRunner()
+
+    publish.run(
+        root,
+        configuration,
+        workspace,
+        options=publish.PublishOptions(
+            build_directory=tmp_path / "build",
+            command_runner=runner,
+            live=False,
+        ),
+    )
+
+    publishable_count = len(workspace.crates)
+    commands = [command for command, _cwd in runner.calls]
+    assert (
+        commands[:publishable_count]
+        == [("cargo", "package", "--allow-dirty")] * publishable_count
+    )
+    assert (
+        commands[publishable_count:]
+        == [("cargo", "publish", "--allow-dirty", "--dry-run")] * publishable_count
     )
 
 

--- a/tests/unit/publish/test_run_integration.py
+++ b/tests/unit/publish/test_run_integration.py
@@ -200,20 +200,21 @@ def test_run_keeps_dry_run_publication_batched(tmp_path: Path) -> None:
     )
 
     staging_root = (tmp_path / "build") / root.name
-    expected_crate_roots = [
-        staging_root / crate.root_path.relative_to(root) for crate in workspace.crates
+    expected_packages = [
+        (
+            ("cargo", "package", "--allow-dirty"),
+            staging_root / crate.root_path.relative_to(root),
+        )
+        for crate in workspace.crates
     ]
-    expected_pairs = [
-        *(
-            (("cargo", "package", "--allow-dirty"), root)
-            for root in expected_crate_roots
-        ),
-        *(
-            (("cargo", "publish", "--allow-dirty", "--dry-run"), root)
-            for root in expected_crate_roots
-        ),
+    expected_dry_runs = [
+        (
+            ("cargo", "publish", "--allow-dirty", "--dry-run"),
+            staging_root / crate.root_path.relative_to(root),
+        )
+        for crate in workspace.crates
     ]
-    assert runner.calls == expected_pairs
+    assert runner.calls == expected_packages + expected_dry_runs
 
 
 def test_run_keeps_live_publication_interleaved(tmp_path: Path) -> None:

--- a/tests/unit/publish/test_run_integration.py
+++ b/tests/unit/publish/test_run_integration.py
@@ -1,4 +1,63 @@
-"""Integration-style tests for :func:`lading.commands.publish.run`."""
+"""Integration-style tests for :func:`lading.commands.publish.run`.
+
+Verifies the end-to-end behaviour of ``run()`` from workspace-root
+resolution through preflight execution, plan construction, and cargo
+command sequencing, using injectable runners and monkeypatched loaders
+rather than real cargo or git processes.
+
+Test coverage
+-------------
+- Workspace root normalisation: ``run`` resolves a relative root before
+  planning.
+- Configuration loading: ``run`` falls back to the active configuration
+  or loads from disk when no active configuration is present.
+- Plan summary formatting: the return value contains structured sections
+  for publishable crates, skipped crates, and configured exclusions.
+- Unpublished workspace dependency override: ``--allow-unpublished-workspace-
+  deps`` downgrades index-lookup failures to warnings and logs the
+  correct INFO message.
+- Dry-run batching: ``live=False`` emits all ``cargo package --allow-dirty``
+  calls before any ``cargo publish --allow-dirty --dry-run`` calls;
+  verified via full ``(command, cwd)`` pair assertions to confirm each
+  operation targets the correct staged crate directory.
+- Live interleaving: ``live=True`` emits a ``cargo package`` immediately
+  followed by ``cargo publish`` for each crate in plan order; verified via
+  full ``(command, cwd)`` pair assertions.
+- No publishable crates: the summary calls out "Crates to publish: none".
+- Missing workspace: a ``FileNotFoundError`` from the workspace loader is
+  converted to a ``WorkspaceModelError``.
+- Configuration errors: ``ConfigurationError`` from the loader propagates
+  unchanged.
+- Preflight invocation location: ``cargo check`` and ``cargo test`` run
+  inside the resolved workspace root, not the staging directory.
+- Test-exclude normalisation: exclusions are sorted, deduplicated, and
+  whitespace-trimmed before being passed to ``cargo test --exclude``.
+- Unit-tests-only mode: ``--all-targets`` is omitted and ``--lib --bins``
+  are injected.
+- Dirty-workspace handling: git status is skipped by default;
+  ``allow_dirty=False`` enforces cleanliness and raises on uncommitted
+  changes.
+- Preflight cargo failures: non-zero ``cargo check`` or ``cargo test``
+  raises ``PublishPreflightError`` containing the subcommand name and exit
+  code.
+
+Test infrastructure
+-------------------
+``CallTrackingRunner``
+    Records ``(command, cwd)`` pairs without executing real subprocesses,
+    enabling post-call assertion of both command and working directory.
+``make_workspace`` / ``make_crate`` / ``make_dependency_chain``
+    Construct in-memory ``WorkspaceGraph`` instances for use as fixtures.
+``make_config`` / ``make_preflight_config``
+    Build ``LadingConfig`` instances with controlled field values.
+``_setup_preflight_test`` / ``_extract_cargo_test_call``
+    Shared helpers from ``preflight_test_utils`` that configure a
+    monkeypatched preflight run and extract the recorded cargo test call.
+``ORIGINAL_PREFLIGHT``
+    The real ``_run_preflight_checks`` function, restored via
+    ``monkeypatch.setattr`` in tests that exercise full preflight
+    behaviour end-to-end.
+"""
 
 from __future__ import annotations
 

--- a/tests/unit/publish/test_snapshot_messages.py
+++ b/tests/unit/publish/test_snapshot_messages.py
@@ -31,11 +31,31 @@ from .conftest import (
     INDEX_MISSING_STDERR_BETA,
     INDEX_MISSING_STDERR_EXTERNAL,
     INDEX_MISSING_STDERR_UNPARSEABLE,
+    CallTrackingRunner,
     _warning_records,
     make_config,
     make_dependency_chain,
     make_workspace,
 )
+
+_PIPELINE_INFO_MESSAGES = frozenset({
+    "Publication mode: live (interleaved per-crate pipeline)",
+    "Publication mode: dry-run (batched two-phase pipeline)",
+    "Dry-run pipeline: packaging complete; starting publish phase",
+    "Live pipeline: starting crate %s",
+    "Live pipeline: completed crate %s",
+})
+
+
+def _pipeline_info_records(
+    caplog: pytest.LogCaptureFixture,
+) -> tuple[tuple[str, tuple[object, ...]], ...]:
+    """Return captured INFO records for publish pipeline operator messages."""
+    return tuple(
+        (record.msg, record.args)
+        for record in caplog.records
+        if record.levelno == logging.INFO and record.msg in _PIPELINE_INFO_MESSAGES
+    )
 
 
 def test_run_rejects_allow_unpublished_with_live(
@@ -191,3 +211,41 @@ def test_index_missing_flag_disabled_message_snapshot(
 
     assert message == snapshot(name="message")
     assert _warning_records(caplog) == snapshot(name="warning")
+
+
+def test_dry_run_pipeline_info_log_snapshot(
+    publish_plan_and_prep: tuple[publish.PublishPlan, publish.PublishPreparation, Path],
+    caplog: pytest.LogCaptureFixture,
+    snapshot: SnapshotAssertion,
+) -> None:
+    """Snapshot dry-run pipeline selector and phase-completion logs."""
+    caplog.set_level(logging.INFO, logger="lading.commands.publish")
+    plan, preparation, _staging_root = publish_plan_and_prep
+
+    publish._dispatch_publication(
+        plan,
+        preparation,
+        options=publish._PublishExecutionOptions(live=False, allow_dirty=True),
+        runner=CallTrackingRunner(),
+    )
+
+    assert _pipeline_info_records(caplog) == snapshot()
+
+
+def test_live_pipeline_info_log_snapshot(
+    publish_plan_and_prep: tuple[publish.PublishPlan, publish.PublishPreparation, Path],
+    caplog: pytest.LogCaptureFixture,
+    snapshot: SnapshotAssertion,
+) -> None:
+    """Snapshot live pipeline selector and per-crate progression logs."""
+    caplog.set_level(logging.INFO, logger="lading.commands.publish")
+    plan, preparation, _staging_root = publish_plan_and_prep
+
+    publish._dispatch_publication(
+        plan,
+        preparation,
+        options=publish._PublishExecutionOptions(live=True, allow_dirty=True),
+        runner=CallTrackingRunner(),
+    )
+
+    assert _pipeline_info_records(caplog) == snapshot()

--- a/tests/unit/publish/test_snapshot_messages.py
+++ b/tests/unit/publish/test_snapshot_messages.py
@@ -47,6 +47,11 @@ _PIPELINE_INFO_MESSAGES = frozenset({
 })
 
 
+class _IndexMissingCase(typ.NamedTuple):
+    stderr: str
+    allow_unpublished: bool
+
+
 def _pipeline_info_records(
     caplog: pytest.LogCaptureFixture,
 ) -> tuple[tuple[str, tuple[object, ...]], ...]:
@@ -119,18 +124,38 @@ def _handle_index_missing_version_message(
     return str(excinfo.value)
 
 
-def test_index_missing_name_extraction_failure_message_snapshot(
+@pytest.mark.parametrize(
+    "case",
+    [
+        pytest.param(
+            _IndexMissingCase(
+                stderr=INDEX_MISSING_STDERR_UNPARSEABLE,
+                allow_unpublished=True,
+            ),
+            id="name_extraction_failure",
+        ),
+        pytest.param(
+            _IndexMissingCase(
+                stderr=INDEX_MISSING_STDERR_BETA,
+                allow_unpublished=False,
+            ),
+            id="flag_disabled",
+        ),
+    ],
+)
+def test_index_missing_version_message_snapshot(
     publish_plan_and_prep: tuple[publish.PublishPlan, publish.PublishPreparation, Path],
     caplog: pytest.LogCaptureFixture,
     snapshot: SnapshotAssertion,
+    case: _IndexMissingCase,
 ) -> None:
-    """Snapshot the fatal message and warning for name extraction failures."""
+    """Snapshot the fatal message and warning for index-missing-version failures."""
     plan, _preparation, _staging_root = publish_plan_and_prep
 
     message = _handle_index_missing_version_message(
         plan,
-        stderr=INDEX_MISSING_STDERR_UNPARSEABLE,
-        allow_unpublished_workspace_deps=True,
+        stderr=case.stderr,
+        allow_unpublished_workspace_deps=case.allow_unpublished,
         caplog=caplog,
     )
 
@@ -194,57 +219,33 @@ def test_index_missing_out_of_plan_message_snapshot(
     assert _warning_records(caplog) == snapshot(name="warning")
 
 
-def test_index_missing_flag_disabled_message_snapshot(
+@pytest.mark.parametrize(
+    "options",
+    [
+        pytest.param(
+            publish._PublishExecutionOptions(live=False, allow_dirty=True),
+            id="dry_run",
+        ),
+        pytest.param(
+            publish._PublishExecutionOptions(live=True, allow_dirty=True),
+            id="live",
+        ),
+    ],
+)
+def test_pipeline_info_log_snapshot(
     publish_plan_and_prep: tuple[publish.PublishPlan, publish.PublishPreparation, Path],
     caplog: pytest.LogCaptureFixture,
     snapshot: SnapshotAssertion,
+    options: publish._PublishExecutionOptions,
 ) -> None:
-    """Snapshot the fatal message and warning when the override is disabled."""
-    plan, _preparation, _staging_root = publish_plan_and_prep
-
-    message = _handle_index_missing_version_message(
-        plan,
-        stderr=INDEX_MISSING_STDERR_BETA,
-        allow_unpublished_workspace_deps=False,
-        caplog=caplog,
-    )
-
-    assert message == snapshot(name="message")
-    assert _warning_records(caplog) == snapshot(name="warning")
-
-
-def test_dry_run_pipeline_info_log_snapshot(
-    publish_plan_and_prep: tuple[publish.PublishPlan, publish.PublishPreparation, Path],
-    caplog: pytest.LogCaptureFixture,
-    snapshot: SnapshotAssertion,
-) -> None:
-    """Snapshot dry-run pipeline selector and phase-completion logs."""
+    """Snapshot pipeline selector and progression logs for each mode."""
     caplog.set_level(logging.INFO, logger="lading.commands.publish")
     plan, preparation, _staging_root = publish_plan_and_prep
 
     publish._dispatch_publication(
         plan,
         preparation,
-        options=publish._PublishExecutionOptions(live=False, allow_dirty=True),
-        runner=CallTrackingRunner(),
-    )
-
-    assert _pipeline_info_records(caplog) == snapshot()
-
-
-def test_live_pipeline_info_log_snapshot(
-    publish_plan_and_prep: tuple[publish.PublishPlan, publish.PublishPreparation, Path],
-    caplog: pytest.LogCaptureFixture,
-    snapshot: SnapshotAssertion,
-) -> None:
-    """Snapshot live pipeline selector and per-crate progression logs."""
-    caplog.set_level(logging.INFO, logger="lading.commands.publish")
-    plan, preparation, _staging_root = publish_plan_and_prep
-
-    publish._dispatch_publication(
-        plan,
-        preparation,
-        options=publish._PublishExecutionOptions(live=True, allow_dirty=True),
+        options=options,
         runner=CallTrackingRunner(),
     )
 


### PR DESCRIPTION
## Summary

This branch changes live publication so `lading publish --live` packages and publishes each crate in publish-plan order before moving to the next crate. That lets later crates resolve freshly published internal dependencies from earlier crates in the same release train.

Dry-run publication keeps the existing batched package-then-publish dry-run flow.

Closes #59.

## Review walkthrough

- Start with [lading/commands/publish.py](https://github.com/leynos/lading/blob/issue-59-lading-publish-live-fails-for-newly-versioned-internal-dependency-chains-because-packaging-runs-before-any-publish/lading/commands/publish.py) to see the extracted crate-level helpers and live pipeline branch.
- Then review [tests/unit/publish/test_packaging.py](https://github.com/leynos/lading/blob/issue-59-lading-publish-live-fails-for-newly-versioned-internal-dependency-chains-because-packaging-runs-before-any-publish/tests/unit/publish/test_packaging.py) for helper and interleaved ordering coverage.
- Finish with [tests/bdd/features/cli.feature](https://github.com/leynos/lading/blob/issue-59-lading-publish-live-fails-for-newly-versioned-internal-dependency-chains-because-packaging-runs-before-any-publish/tests/bdd/features/cli.feature), [tests/bdd/steps/test_publish_then_steps.py](https://github.com/leynos/lading/blob/issue-59-lading-publish-live-fails-for-newly-versioned-internal-dependency-chains-because-packaging-runs-before-any-publish/tests/bdd/steps/test_publish_then_steps.py), and [tests/unit/publish/test_run_integration.py](https://github.com/leynos/lading/blob/issue-59-lading-publish-live-fails-for-newly-versioned-internal-dependency-chains-because-packaging-runs-before-any-publish/tests/unit/publish/test_run_integration.py) for CLI-level live ordering and retained dry-run batching.

## Validation

- `coderabbit review --agent`: findings 0
- `make check-fmt`: passed
- `make lint`: passed
- `make test`: 468 passed
- `make typecheck`: passed
