### PR TITLE
Remove dead IPC-timeout constructors on CargoMetadataError (#98)

### DIFF
--- a/docs/cmd-mox-usage-guide.md
+++ b/docs/cmd-mox-usage-guide.md
@@ -287,11 +287,13 @@ server.
   connection waits. When unset, the default is `5.0` seconds. The value is
   validated when the runner resolves the timeout: a non-numeric value raises
   `CmdMoxError` with the message `Invalid CMOX_IPC_TIMEOUT value`, and a value
-  that is zero, negative, or `NaN` raises `CmdMoxError` with the message
-  `CMOX_IPC_TIMEOUT must be positive`. These two operator-facing messages have a
-  single canonical home: the module constants `INVALID_IPC_TIMEOUT_MESSAGE` and
-  `NON_POSITIVE_IPC_TIMEOUT_MESSAGE` in `lading/testing/cmd_mox_runner.py`. No
-  other module should duplicate them; rewording either constant is pinned by a
-  syrupy snapshot so the change is deliberate and reviewed.
+  that is not a finite positive number — zero, negative, `NaN`, or infinite
+  (including overflowing literals such as `1e400`) — raises `CmdMoxError` with
+  the message `CMOX_IPC_TIMEOUT must be positive`. These two operator-facing
+  messages have a single canonical home: the module constants
+  `INVALID_IPC_TIMEOUT_MESSAGE` and `NON_POSITIVE_IPC_TIMEOUT_MESSAGE` in
+  `lading/testing/cmd_mox_runner.py`. No other module should duplicate them;
+  rewording either constant is pinned by a syrupy snapshot so the change is
+  deliberate and reviewed.
 
 Most tests should rely on the fixture to manage these variables.

--- a/docs/cmd-mox-usage-guide.md
+++ b/docs/cmd-mox-usage-guide.md
@@ -284,6 +284,14 @@ server.
   `CmdMox` fixture sets this automatically when the server starts. Shims exit
   with an error if the variable is missing.
 - `CMOX_IPC_TIMEOUT` – communication timeout in seconds. Override this to tune
-  connection waits. When unset, the default is `5.0` seconds.
+  connection waits. When unset, the default is `5.0` seconds. The value is
+  validated when the runner resolves the timeout: a non-numeric value raises
+  `CmdMoxError` with the message `Invalid CMOX_IPC_TIMEOUT value`, and a value
+  that is zero, negative, or `NaN` raises `CmdMoxError` with the message
+  `CMOX_IPC_TIMEOUT must be positive`. These two operator-facing messages have a
+  single canonical home: the module constants `INVALID_IPC_TIMEOUT_MESSAGE` and
+  `NON_POSITIVE_IPC_TIMEOUT_MESSAGE` in `lading/testing/cmd_mox_runner.py`. No
+  other module should duplicate them; rewording either constant is pinned by a
+  syrupy snapshot so the change is deliberate and reviewed.
 
 Most tests should rely on the fixture to manage these variables.

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -538,6 +538,14 @@ around command execution. `lading bump` uses the runtime runner directly for
 lockfile refreshes, while `lading publish` uses `_invoke` where failures should
 surface as `PublishPreflightError`.
 
+The cmd-mox runner validates `CMOX_IPC_TIMEOUT` in `_resolve_cmd_mox_timeout`.
+The two operator-facing messages it raises live as a single source of truth in
+the module constants `INVALID_IPC_TIMEOUT_MESSAGE` and
+`NON_POSITIVE_IPC_TIMEOUT_MESSAGE` in `lading/testing/cmd_mox_runner.py`; their
+values are pinned by a syrupy snapshot. See the
+[cmd-mox usage guide](./cmd-mox-usage-guide.md#environment-variables) for the
+operator-facing description of the variable and its failure modes.
+
 #### Subprocess invocation logging
 
 `subprocess_runner` emits **exactly one** log record per external command

--- a/lading/testing/cmd_mox_runner.py
+++ b/lading/testing/cmd_mox_runner.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import collections.abc as cabc
 import logging
+import math
 import os
 import sys
 import typing as typ
@@ -21,7 +22,13 @@ from lading.runtime.subprocess_runner import (
 from lading.utils.process import log_command_invocation
 
 _LOGGER = logging.getLogger(__name__)
+
 _CMD_MOX_TIMEOUT_DEFAULT = 5.0
+
+# Canonical operator-facing IPC-timeout messages (issue #98): these exist
+# only here; no other module may duplicate them.
+INVALID_IPC_TIMEOUT_MESSAGE = "Invalid CMOX_IPC_TIMEOUT value"
+NON_POSITIVE_IPC_TIMEOUT_MESSAGE = "CMOX_IPC_TIMEOUT must be positive"
 
 
 class CmdMoxError(LadingError):
@@ -111,11 +118,11 @@ def _resolve_cmd_mox_timeout(raw_timeout: str | None) -> float:
     try:
         timeout = float(raw_timeout)
     except (TypeError, ValueError) as exc:
-        message = "Invalid CMOX_IPC_TIMEOUT value"
-        raise CmdMoxError(message) from exc
-    if timeout <= 0:
-        message = "CMOX_IPC_TIMEOUT must be positive"
-        raise CmdMoxError(message)
+        raise CmdMoxError(INVALID_IPC_TIMEOUT_MESSAGE) from exc
+    # NaN compares false against everything, so it must be rejected
+    # explicitly alongside zero and negative values.
+    if math.isnan(timeout) or timeout <= 0:
+        raise CmdMoxError(NON_POSITIVE_IPC_TIMEOUT_MESSAGE)
     return timeout
 
 

--- a/lading/testing/cmd_mox_runner.py
+++ b/lading/testing/cmd_mox_runner.py
@@ -1,4 +1,27 @@
-"""cmd-mox-backed implementation of the command runner port."""
+"""cmd-mox-backed implementation of the command runner port.
+
+This module adapts cmd-mox's IPC server to the ``CommandRunner`` protocol
+defined in :mod:`lading.runtime`, so tests can route ``cargo`` and ``git``
+invocations through recorded cmd-mox expectations instead of spawning real
+subprocesses. :func:`cmd_mox_runner` is the adapter entry point: it validates
+the cmd-mox environment (the IPC socket path and the ``CMOX_IPC_TIMEOUT``
+timeout), normalises cargo subcommands to the namespaced names cmd-mox
+expects, sends the invocation over the IPC socket, and runs passthrough
+directives locally through :mod:`lading.runtime.subprocess_runner` so streaming
+output is preserved.
+
+It is the test-time counterpart of the production
+:mod:`lading.runtime.subprocess_runner` adapter. Command modules such as
+:mod:`lading.commands.publish_execution` and :mod:`lading.workspace.metadata`
+type against the shared ``CommandRunner`` protocol and accept either adapter,
+so swapping this runner in (typically via
+:func:`lading.workspace.metadata.use_command_runner`) requires no change at the
+call sites. The two operator-facing IPC-timeout error messages have their
+single canonical home here as the module constants
+:data:`INVALID_IPC_TIMEOUT_MESSAGE` and
+:data:`NON_POSITIVE_IPC_TIMEOUT_MESSAGE`; no other module should duplicate
+them.
+"""
 
 from __future__ import annotations
 
@@ -118,12 +141,20 @@ def _resolve_cmd_mox_timeout(raw_timeout: str | None) -> float:
     try:
         timeout = float(raw_timeout)
     except (TypeError, ValueError) as exc:
+        _LOGGER.warning(
+            "Rejecting CMOX_IPC_TIMEOUT=%r: value is not a number", raw_timeout
+        )
         raise CmdMoxError(INVALID_IPC_TIMEOUT_MESSAGE) from exc
     # Reject every value that is not a finite positive number. NaN compares
     # false against everything, and an infinite timeout slips past ``> 0`` yet
     # the socket layer rejects it with OverflowError when applied, so require
     # finiteness explicitly alongside the positivity guard.
     if not math.isfinite(timeout) or timeout <= 0:
+        _LOGGER.warning(
+            "Rejecting CMOX_IPC_TIMEOUT=%r: %s is not a finite positive number",
+            raw_timeout,
+            timeout,
+        )
         raise CmdMoxError(NON_POSITIVE_IPC_TIMEOUT_MESSAGE)
     return timeout
 

--- a/lading/testing/cmd_mox_runner.py
+++ b/lading/testing/cmd_mox_runner.py
@@ -119,9 +119,11 @@ def _resolve_cmd_mox_timeout(raw_timeout: str | None) -> float:
         timeout = float(raw_timeout)
     except (TypeError, ValueError) as exc:
         raise CmdMoxError(INVALID_IPC_TIMEOUT_MESSAGE) from exc
-    # NaN compares false against everything, so it must be rejected
-    # explicitly alongside zero and negative values.
-    if math.isnan(timeout) or timeout <= 0:
+    # Reject every value that is not a finite positive number. NaN compares
+    # false against everything, and an infinite timeout slips past ``> 0`` yet
+    # the socket layer rejects it with OverflowError when applied, so require
+    # finiteness explicitly alongside the positivity guard.
+    if not math.isfinite(timeout) or timeout <= 0:
         raise CmdMoxError(NON_POSITIVE_IPC_TIMEOUT_MESSAGE)
     return timeout
 

--- a/lading/workspace/metadata.py
+++ b/lading/workspace/metadata.py
@@ -24,16 +24,6 @@ if typ.TYPE_CHECKING:  # pragma: no cover - import-time typing aids only
 class CargoMetadataError(LadingError):
     """Raised when ``cargo metadata`` cannot be executed successfully."""
 
-    @classmethod
-    def invalid_ipc_timeout(cls) -> CargoMetadataError:
-        """Return an error for malformed IPC timeout values."""
-        return cls("Invalid CMOX_IPC_TIMEOUT value")
-
-    @classmethod
-    def non_positive_ipc_timeout(cls) -> CargoMetadataError:
-        """Return an error when the IPC timeout is non-positive."""
-        return cls("CMOX_IPC_TIMEOUT must be positive")
-
 
 class CargoExecutableNotFoundError(CargoMetadataError):
     """Raised when the ``cargo`` executable is missing from ``PATH``."""

--- a/lading/workspace/metadata.py
+++ b/lading/workspace/metadata.py
@@ -1,4 +1,20 @@
-"""Interfaces for invoking ``cargo metadata``."""
+"""Execute and parse ``cargo metadata`` for workspace discovery.
+
+This module is the workspace layer's gateway to ``cargo metadata``: callers use
+:func:`load_cargo_metadata` to obtain the parsed JSON payload that downstream
+:mod:`lading.workspace` code (such as :mod:`lading.workspace.models`) turns into
+the workspace and crate model. It owns the ``CargoMetadataError`` hierarchy,
+which classifies the ways the invocation can fail — a missing ``cargo``
+executable, a non-zero exit, or unparseable output — so command modules can map
+those failures onto their own domain errors.
+
+Execution is delegated to the shared ``CommandRunner`` protocol from
+:mod:`lading.runtime` rather than calling :mod:`subprocess` directly. By default
+the production :mod:`lading.runtime.subprocess_runner` adapter is used, but
+:func:`use_command_runner` installs a context-local override so tests can route
+the same calls through the cmd-mox adapter in
+:mod:`lading.testing.cmd_mox_runner` without touching the call sites.
+"""
 
 from __future__ import annotations
 

--- a/tests/unit/__snapshots__/test_cmd_mox_integration.ambr
+++ b/tests/unit/__snapshots__/test_cmd_mox_integration.ambr
@@ -1,0 +1,7 @@
+# serializer version: 1
+# name: test_ipc_timeout_messages_are_stable
+  'Invalid CMOX_IPC_TIMEOUT value'
+# ---
+# name: test_ipc_timeout_messages_are_stable.1
+  'CMOX_IPC_TIMEOUT must be positive'
+# ---

--- a/tests/unit/test_cmd_mox_integration.py
+++ b/tests/unit/test_cmd_mox_integration.py
@@ -2,15 +2,20 @@
 
 from __future__ import annotations
 
+import math
 import typing as typ
 from types import SimpleNamespace
 
+import hypothesis.strategies as st
 import pytest
+from hypothesis import given
 
 from lading.testing import cmd_mox_runner
 
 if typ.TYPE_CHECKING:
     from pathlib import Path
+
+    from syrupy.assertion import SnapshotAssertion
 
 
 def test_cmd_mox_runner_requires_socket(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -28,6 +33,42 @@ def test_resolve_cmd_mox_timeout_validates_values() -> None:
     for value in ("0", "-1", "abc"):
         with pytest.raises(cmd_mox_runner.CmdMoxError):
             cmd_mox_runner._resolve_cmd_mox_timeout(value)
+
+
+def test_ipc_timeout_messages_are_stable(snapshot: SnapshotAssertion) -> None:
+    """The canonical IPC-timeout messages change only deliberately."""
+    assert snapshot == cmd_mox_runner.INVALID_IPC_TIMEOUT_MESSAGE
+    assert snapshot == cmd_mox_runner.NON_POSITIVE_IPC_TIMEOUT_MESSAGE
+
+
+@given(value=st.one_of(st.none(), st.floats(), st.text(max_size=12)))
+def test_resolve_cmd_mox_timeout_domain(value: float | str | None) -> None:
+    """Resolution is total: default, the parsed positive value, or CmdMoxError.
+
+    ``None`` yields the default, finite positive floats round-trip, and every
+    other input raises :class:`CmdMoxError` carrying one of the two canonical
+    messages.
+    """
+    raw = value if value is None or isinstance(value, str) else repr(value)
+    try:
+        parsed: float | None = None if raw is None else float(raw)
+    except ValueError:
+        parsed = math.nan  # Marker: unparseable input.
+
+    if raw is None:
+        assert (
+            cmd_mox_runner._resolve_cmd_mox_timeout(raw)
+            == cmd_mox_runner._CMD_MOX_TIMEOUT_DEFAULT
+        )
+    elif parsed is not None and parsed > 0:
+        assert cmd_mox_runner._resolve_cmd_mox_timeout(raw) == parsed
+    else:
+        with pytest.raises(cmd_mox_runner.CmdMoxError) as excinfo:
+            cmd_mox_runner._resolve_cmd_mox_timeout(raw)
+        assert str(excinfo.value) in {
+            cmd_mox_runner.INVALID_IPC_TIMEOUT_MESSAGE,
+            cmd_mox_runner.NON_POSITIVE_IPC_TIMEOUT_MESSAGE,
+        }
 
 
 def test_cmd_mox_runner_executes_via_ipc(

--- a/tests/unit/test_cmd_mox_integration.py
+++ b/tests/unit/test_cmd_mox_integration.py
@@ -26,13 +26,50 @@ def test_cmd_mox_runner_requires_socket(monkeypatch: pytest.MonkeyPatch) -> None
         cmd_mox_runner.cmd_mox_runner(("cargo", "metadata"))
 
 
-def test_resolve_cmd_mox_timeout_validates_values() -> None:
-    """Timeout parsing should reject non-positive and non-numeric values."""
-    assert cmd_mox_runner._resolve_cmd_mox_timeout(None) > 0
-    assert cmd_mox_runner._resolve_cmd_mox_timeout("2.5") == 2.5
-    for value in ("0", "-1", "abc"):
-        with pytest.raises(cmd_mox_runner.CmdMoxError):
-            cmd_mox_runner._resolve_cmd_mox_timeout(value)
+@pytest.mark.parametrize(
+    ("raw", "expected"),
+    [
+        (None, cmd_mox_runner._CMD_MOX_TIMEOUT_DEFAULT),
+        ("2.5", 2.5),
+        ("0.001", 0.001),
+        ("1000000", 1_000_000.0),
+    ],
+)
+def test_resolve_cmd_mox_timeout_accepts_valid(
+    raw: str | None, expected: float
+) -> None:
+    """A missing or finite positive value resolves to a usable timeout."""
+    assert cmd_mox_runner._resolve_cmd_mox_timeout(raw) == expected
+
+
+@pytest.mark.parametrize(
+    ("raw", "expected_message"),
+    [
+        # Unparseable input → the invalid-value message.
+        ("abc", cmd_mox_runner.INVALID_IPC_TIMEOUT_MESSAGE),
+        ("", cmd_mox_runner.INVALID_IPC_TIMEOUT_MESSAGE),
+        ("1.2.3", cmd_mox_runner.INVALID_IPC_TIMEOUT_MESSAGE),
+        # Parses but is not a finite positive number → the non-positive message.
+        ("0", cmd_mox_runner.NON_POSITIVE_IPC_TIMEOUT_MESSAGE),
+        ("-1", cmd_mox_runner.NON_POSITIVE_IPC_TIMEOUT_MESSAGE),
+        ("nan", cmd_mox_runner.NON_POSITIVE_IPC_TIMEOUT_MESSAGE),
+        ("inf", cmd_mox_runner.NON_POSITIVE_IPC_TIMEOUT_MESSAGE),
+        ("Infinity", cmd_mox_runner.NON_POSITIVE_IPC_TIMEOUT_MESSAGE),
+        # Overflows to infinity without raising in ``float``.
+        ("1e400", cmd_mox_runner.NON_POSITIVE_IPC_TIMEOUT_MESSAGE),
+    ],
+)
+def test_resolve_cmd_mox_timeout_rejects_with_canonical_message(
+    raw: str, expected_message: str
+) -> None:
+    """Each class of invalid input raises its own canonical message.
+
+    Pinning the message per input class locks the mapping so the two strings
+    cannot be silently swapped between parse failures and out-of-range values.
+    """
+    with pytest.raises(cmd_mox_runner.CmdMoxError) as excinfo:
+        cmd_mox_runner._resolve_cmd_mox_timeout(raw)
+    assert str(excinfo.value) == expected_message
 
 
 def test_ipc_timeout_messages_are_stable(snapshot: SnapshotAssertion) -> None:
@@ -45,30 +82,35 @@ def test_ipc_timeout_messages_are_stable(snapshot: SnapshotAssertion) -> None:
 def test_resolve_cmd_mox_timeout_domain(value: float | str | None) -> None:
     """Resolution is total: default, the parsed positive value, or CmdMoxError.
 
-    ``None`` yields the default, finite positive floats round-trip, and every
-    other input raises :class:`CmdMoxError` carrying one of the two canonical
-    messages.
+    ``None`` yields the default and finite positive floats round-trip. Every
+    other input raises :class:`CmdMoxError`: unparseable strings carry
+    ``INVALID_IPC_TIMEOUT_MESSAGE``, while values that parse but are zero,
+    negative, NaN, or infinite carry ``NON_POSITIVE_IPC_TIMEOUT_MESSAGE``.
     """
     raw = value if value is None or isinstance(value, str) else repr(value)
-    try:
-        parsed: float | None = None if raw is None else float(raw)
-    except ValueError:
-        parsed = math.nan  # Marker: unparseable input.
 
     if raw is None:
         assert (
             cmd_mox_runner._resolve_cmd_mox_timeout(raw)
             == cmd_mox_runner._CMD_MOX_TIMEOUT_DEFAULT
         )
-    elif parsed is not None and parsed > 0:
-        assert cmd_mox_runner._resolve_cmd_mox_timeout(raw) == parsed
-    else:
+        return
+
+    try:
+        parsed = float(raw)
+    except ValueError:
         with pytest.raises(cmd_mox_runner.CmdMoxError) as excinfo:
             cmd_mox_runner._resolve_cmd_mox_timeout(raw)
-        assert str(excinfo.value) in {
-            cmd_mox_runner.INVALID_IPC_TIMEOUT_MESSAGE,
-            cmd_mox_runner.NON_POSITIVE_IPC_TIMEOUT_MESSAGE,
-        }
+        assert str(excinfo.value) == cmd_mox_runner.INVALID_IPC_TIMEOUT_MESSAGE
+        return
+
+    if math.isfinite(parsed) and parsed > 0:
+        assert cmd_mox_runner._resolve_cmd_mox_timeout(raw) == parsed
+        return
+
+    with pytest.raises(cmd_mox_runner.CmdMoxError) as excinfo:
+        cmd_mox_runner._resolve_cmd_mox_timeout(raw)
+    assert str(excinfo.value) == cmd_mox_runner.NON_POSITIVE_IPC_TIMEOUT_MESSAGE
 
 
 def test_cmd_mox_runner_executes_via_ipc(

--- a/tests/unit/test_cmd_mox_integration.py
+++ b/tests/unit/test_cmd_mox_integration.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 import math
 import string
 import typing as typ
@@ -61,16 +62,28 @@ def test_resolve_cmd_mox_timeout_accepts_valid(
     ],
 )
 def test_resolve_cmd_mox_timeout_rejects_with_canonical_message(
-    raw: str, expected_message: str
+    raw: str, expected_message: str, caplog: pytest.LogCaptureFixture
 ) -> None:
-    """Each class of invalid input raises its own canonical message.
+    """Each class of invalid input raises its own canonical message and logs.
 
     Pinning the message per input class locks the mapping so the two strings
     cannot be silently swapped between parse failures and out-of-range values.
+    A diagnostic warning carrying the rejected raw value is emitted so the
+    failure can be traced without reading the source.
     """
-    with pytest.raises(cmd_mox_runner.CmdMoxError) as excinfo:
+    with (
+        caplog.at_level(logging.WARNING, logger=cmd_mox_runner.__name__),
+        pytest.raises(cmd_mox_runner.CmdMoxError) as excinfo,
+    ):
         cmd_mox_runner._resolve_cmd_mox_timeout(raw)
     assert str(excinfo.value) == expected_message
+    assert [
+        record
+        for record in caplog.records
+        if record.levelno == logging.WARNING
+        and "CMOX_IPC_TIMEOUT" in record.getMessage()
+        and repr(raw) in record.getMessage()
+    ]
 
 
 def test_ipc_timeout_messages_are_stable(snapshot: SnapshotAssertion) -> None:

--- a/tests/unit/test_cmd_mox_integration.py
+++ b/tests/unit/test_cmd_mox_integration.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import math
+import string
 import typing as typ
 from types import SimpleNamespace
 
@@ -78,39 +79,85 @@ def test_ipc_timeout_messages_are_stable(snapshot: SnapshotAssertion) -> None:
     assert snapshot == cmd_mox_runner.NON_POSITIVE_IPC_TIMEOUT_MESSAGE
 
 
-@given(value=st.one_of(st.none(), st.floats(), st.text(max_size=12)))
-def test_resolve_cmd_mox_timeout_domain(value: float | str | None) -> None:
-    """Resolution is total: default, the parsed positive value, or CmdMoxError.
+class _TimeoutCase(typ.NamedTuple):
+    """A timeout input paired with the resolver outcome it should produce."""
 
-    ``None`` yields the default and finite positive floats round-trip. Every
-    other input raises :class:`CmdMoxError`: unparseable strings carry
-    ``INVALID_IPC_TIMEOUT_MESSAGE``, while values that parse but are zero,
-    negative, NaN, or infinite carry ``NON_POSITIVE_IPC_TIMEOUT_MESSAGE``.
+    raw: str | None
+    resolves_to: float | None
+    raises_message: str | None
+
+
+# Lowercase letters that can never form a float literal: this excludes the
+# characters that spell "inf"/"infinity"/"nan" and the exponent marker "e", so
+# any string built from them is guaranteed to be unparseable by ``float``.
+_NON_NUMERIC_ALPHABET = "".join(
+    ch for ch in string.ascii_lowercase if ch not in "einfaty"
+)
+
+
+def _timeout_cases() -> st.SearchStrategy[_TimeoutCase]:
+    """Generate timeout inputs grouped by the resolver behaviour they trigger.
+
+    Each input class is constructed directly, so the expected outcome travels
+    with the input instead of being re-derived from the implementation's own
+    parsing. ``None`` and finite positive floats resolve to a timeout;
+    consonant-only strings are unparseable; zero, negative, NaN, and infinite
+    values parse but fall outside the finite positive domain.
     """
-    raw = value if value is None or isinstance(value, str) else repr(value)
-
-    if raw is None:
-        assert (
-            cmd_mox_runner._resolve_cmd_mox_timeout(raw)
-            == cmd_mox_runner._CMD_MOX_TIMEOUT_DEFAULT
+    default = st.just(_TimeoutCase(None, cmd_mox_runner._CMD_MOX_TIMEOUT_DEFAULT, None))
+    finite_positive = st.floats(
+        min_value=0.0,
+        max_value=1e6,
+        exclude_min=True,
+        allow_nan=False,
+        allow_infinity=False,
+    ).map(lambda value: _TimeoutCase(repr(value), value, None))
+    unparseable = st.text(alphabet=_NON_NUMERIC_ALPHABET, min_size=1, max_size=12).map(
+        lambda raw: _TimeoutCase(raw, None, cmd_mox_runner.INVALID_IPC_TIMEOUT_MESSAGE)
+    )
+    out_of_range = st.one_of(
+        st.floats(max_value=0.0, allow_nan=False, allow_infinity=False),
+        st.sampled_from([math.nan, math.inf, -math.inf]),
+    ).map(
+        lambda value: _TimeoutCase(
+            repr(value), None, cmd_mox_runner.NON_POSITIVE_IPC_TIMEOUT_MESSAGE
         )
-        return
+    )
+    return st.one_of(default, finite_positive, unparseable, out_of_range)
 
-    try:
-        parsed = float(raw)
-    except ValueError:
-        with pytest.raises(cmd_mox_runner.CmdMoxError) as excinfo:
-            cmd_mox_runner._resolve_cmd_mox_timeout(raw)
-        assert str(excinfo.value) == cmd_mox_runner.INVALID_IPC_TIMEOUT_MESSAGE
-        return
 
-    if math.isfinite(parsed) and parsed > 0:
-        assert cmd_mox_runner._resolve_cmd_mox_timeout(raw) == parsed
+@given(case=_timeout_cases())
+def test_resolve_cmd_mox_timeout_classes(case: _TimeoutCase) -> None:
+    """Each input class resolves or raises exactly as its construction declares.
+
+    The expectation is attached to the generated input, so this test asserts
+    the contract directly without mirroring the resolver's parsing logic.
+    """
+    if case.raises_message is None:
+        resolved = cmd_mox_runner._resolve_cmd_mox_timeout(case.raw)
+        assert resolved == case.resolves_to
         return
 
     with pytest.raises(cmd_mox_runner.CmdMoxError) as excinfo:
-        cmd_mox_runner._resolve_cmd_mox_timeout(raw)
-    assert str(excinfo.value) == cmd_mox_runner.NON_POSITIVE_IPC_TIMEOUT_MESSAGE
+        cmd_mox_runner._resolve_cmd_mox_timeout(case.raw)
+    assert str(excinfo.value) == case.raises_message
+
+
+@given(value=st.one_of(st.none(), st.floats(), st.text(max_size=12)))
+def test_resolve_cmd_mox_timeout_is_total(value: float | str | None) -> None:
+    """Resolution returns a finite positive timeout or raises ``CmdMoxError``.
+
+    This postcondition holds for every input without restating the parsing
+    rules, guarding against a regression that returns an unusable timeout
+    (zero, negative, NaN, or infinite) for some unforeseen value.
+    """
+    raw = value if value is None or isinstance(value, str) else repr(value)
+    try:
+        resolved = cmd_mox_runner._resolve_cmd_mox_timeout(raw)
+    except cmd_mox_runner.CmdMoxError:
+        return
+    assert math.isfinite(resolved)
+    assert resolved > 0
 
 
 def test_cmd_mox_runner_executes_via_ipc(

--- a/tests/unit/test_metadata_helpers.py
+++ b/tests/unit/test_metadata_helpers.py
@@ -3,19 +3,8 @@
 from __future__ import annotations
 
 from lading.runtime import coerce_text
-from lading.workspace import metadata as metadata_module
 
 
 def test_coerce_text_handles_bytes() -> None:
     """Byte streams should be decoded to strings."""
     assert coerce_text(b"bytes") == "bytes"
-
-
-def test_error_convenience_constructors() -> None:
-    """Helper constructors should expose descriptive messages."""
-    assert "Invalid CMOX_IPC_TIMEOUT value" in str(
-        metadata_module.CargoMetadataError.invalid_ipc_timeout()
-    )
-    assert "must be positive" in str(
-        metadata_module.CargoMetadataError.non_positive_ipc_timeout()
-    )


### PR DESCRIPTION
## Summary

Closes #98

- Delete `CargoMetadataError.invalid_ipc_timeout()` / `non_positive_ipc_timeout()` — dead code referenced only by their own test, duplicating cmd-mox messages on the wrong domain class.
- Define the two messages once as module constants in `lading/testing/cmd_mox_runner.py` (`INVALID_IPC_TIMEOUT_MESSAGE`, `NON_POSITIVE_IPC_TIMEOUT_MESSAGE`); `_resolve_cmd_mox_timeout` references them.
- Bug fix surfaced by the property test: NaN timeouts previously passed the `timeout <= 0` guard and were returned as valid; they now raise `CmdMoxError` with the canonical non-positive message.

## Testing

- Hypothesis property test covers the timeout-resolution domain: `None` → default; finite positive → that value; everything else (non-numeric, zero, negative, NaN) → `CmdMoxError` with one of the two canonical messages.
- syrupy snapshots pin both message strings so rewording is a deliberate, reviewed change.
- Dead assertions removed from `tests/unit/test_metadata_helpers.py`.
- `make check-fmt`, `make lint`, `make typecheck`, and `make test` (556 passed) all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Consolidate and canonicalize cmd-mox IPC-timeout error handling while tightening timeout validation and tests.

Bug Fixes:
- Reject NaN cmd-mox IPC timeout values by treating them as invalid/non-positive and raising CmdMoxError with the canonical message.

Enhancements:
- Define canonical IPC-timeout error message constants in cmd_mox_runner and use them as the single source of truth across the codebase.
- Remove unused CargoMetadataError IPC-timeout convenience constructors that duplicated cmd-mox error messages.

Documentation:
- Document the validation rules and canonical error messages for CMOX_IPC_TIMEOUT in the cmd-mox usage guide and developers guide.

Tests:
- Add property-based and snapshot tests to cover the full CMOX_IPC_TIMEOUT resolution domain and pin the canonical error messages, while removing obsolete tests tied to deleted helpers.