### PR TITLE
Centralise hardcoded Cargo dependency-section names (#103)

### DIFF
--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -127,7 +127,7 @@ Cargo dependency-section names (`dependencies`, `dev-dependencies`, and
 (`bump_docs.update_toml_snippet_dependencies`,
 `bump._workspace_dependency_sections`) or map dependency kinds to sections
 (`bump._DEPENDENCY_SECTION_BY_KIND`) must derive from this constant rather than
-re-declaring the literals, so a change to the recognised section set is made in
+re-declaring the literals, so a change to the recognized section set is made in
 exactly one place.
 
 ## Workspace discovery helpers

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -121,6 +121,15 @@ observed without invoking real Cargo processes.
 updates. The output formatter labels these paths as `(lockfile)` so operators
 can see which generated files need review and commit.
 
+`lading.commands.bump_toml.DEPENDENCY_SECTIONS` is the canonical vocabulary of
+Cargo dependency-section names (`dependencies`, `dev-dependencies`, and
+`build-dependencies`). Modules that iterate dependency sections
+(`bump_docs.update_toml_snippet_dependencies`,
+`bump._workspace_dependency_sections`) or map dependency kinds to sections
+(`bump._DEPENDENCY_SECTION_BY_KIND`) must derive from this constant rather than
+re-declaring the literals, so a change to the recognised section set is made in
+exactly one place.
+
 ## Workspace discovery helpers
 
 ### Workspace path normalisation (`lading/utils/path.py`)

--- a/lading/commands/bump.py
+++ b/lading/commands/bump.py
@@ -24,11 +24,15 @@ _WORKSPACE_SELECTORS: typ.Final[tuple[tuple[str, ...], ...]] = (
     ("workspace", "package"),
 )
 
+# Derived from the canonical section vocabulary so the kind mapping cannot
+# drift from ``bump_toml.DEPENDENCY_SECTIONS``.
+_NORMAL_SECTION, _DEV_SECTION, _BUILD_SECTION = bump_toml.DEPENDENCY_SECTIONS
+
 _DEPENDENCY_SECTION_BY_KIND: typ.Final[dict[str | None, str]] = {
-    None: "dependencies",
-    "normal": "dependencies",
-    "dev": "dev-dependencies",
-    "build": "build-dependencies",
+    None: _NORMAL_SECTION,
+    "normal": _NORMAL_SECTION,
+    "dev": _DEV_SECTION,
+    "build": _BUILD_SECTION,
 }
 
 LOGGER = logging.getLogger(__name__)
@@ -528,11 +532,7 @@ def _workspace_dependency_sections(
     crate_names = {name for name in updated_crates if name}
     if not crate_names:
         return {}
-    return {
-        "dependencies": set(crate_names),
-        "dev-dependencies": set(crate_names),
-        "build-dependencies": set(crate_names),
-    }
+    return {section: set(crate_names) for section in bump_toml.DEPENDENCY_SECTIONS}
 
 
 def _dependency_sections_for_crate(

--- a/lading/commands/bump.py
+++ b/lading/commands/bump.py
@@ -549,7 +549,7 @@ def _dependency_sections_for_crate(
     for dependency in crate.dependencies:
         if dependency.name not in targets:
             continue
-        section = _DEPENDENCY_SECTION_BY_KIND.get(dependency.kind, "dependencies")
+        section = _DEPENDENCY_SECTION_BY_KIND.get(dependency.kind, _NORMAL_SECTION)
         # ``manifest_name`` preserves the dependency key used in the manifest.
         # When a crate is aliased (e.g. ``alpha-core = { package = "alpha" }``)
         # the workspace dependency name remains ``alpha`` while the manifest

--- a/lading/commands/bump_docs.py
+++ b/lading/commands/bump_docs.py
@@ -348,7 +348,7 @@ def update_toml_snippet_dependencies(
         return False
 
     changed = False
-    for section in ("dependencies", "dev-dependencies", "build-dependencies"):
+    for section in bump_toml.DEPENDENCY_SECTIONS:
         if _update_single_dependency_section(
             document, section, dependency_targets, target_version
         ):

--- a/lading/commands/bump_toml.py
+++ b/lading/commands/bump_toml.py
@@ -30,7 +30,9 @@ NON_DIGIT_PREFIX: typ.Final[re.Pattern[str]] = re.compile(r"^([^\d]*)")
 
 # Canonical Cargo dependency-section vocabulary (issue #103). Every module
 # that iterates or maps dependency sections must reference this constant
-# rather than re-declaring the literals.
+# rather than re-declaring the literals. Order is significant: the elements
+# are the normal, dev, and build sections respectively, and ``bump`` unpacks
+# them positionally into ``_NORMAL_SECTION``/``_DEV_SECTION``/``_BUILD_SECTION``.
 DEPENDENCY_SECTIONS: typ.Final[tuple[str, str, str]] = (
     "dependencies",
     "dev-dependencies",

--- a/lading/commands/bump_toml.py
+++ b/lading/commands/bump_toml.py
@@ -28,6 +28,15 @@ _TABLE_LIKE_TYPES: typ.Final[tuple[type[Table], type[OutOfOrderTableProxy]]] = (
 
 NON_DIGIT_PREFIX: typ.Final[re.Pattern[str]] = re.compile(r"^([^\d]*)")
 
+# Canonical Cargo dependency-section vocabulary (issue #103). Every module
+# that iterates or maps dependency sections must reference this constant
+# rather than re-declaring the literals.
+DEPENDENCY_SECTIONS: typ.Final[tuple[str, str, str]] = (
+    "dependencies",
+    "dev-dependencies",
+    "build-dependencies",
+)
+
 
 def value_as_string(value: object) -> str | None:
     """Return ``value`` as a string if possible."""

--- a/tests/unit/__snapshots__/test_dependency_sections.ambr
+++ b/tests/unit/__snapshots__/test_dependency_sections.ambr
@@ -1,0 +1,25 @@
+# serializer version: 1
+# name: test_multi_section_manifest_rewrite_snapshot
+  '''
+  [dependencies]
+  alpha = "2.0.0"
+  other = "0.9.0"
+  
+  [dev-dependencies]
+  alpha = "2.0.0"
+  other = "0.9.0"
+  
+  [build-dependencies]
+  alpha = "2.0.0"
+  other = "0.9.0"
+  
+  [decoy-dependencies]
+  alpha = "1.0.0"
+  other = "0.9.0"
+  
+  [tooling]
+  alpha = "1.0.0"
+  other = "0.9.0"
+  
+  '''
+# ---

--- a/tests/unit/test_bump_readme.py
+++ b/tests/unit/test_bump_readme.py
@@ -16,10 +16,12 @@ from lading.workspace import WorkspaceCrate
 if typ.TYPE_CHECKING:
     from syrupy.assertion import SnapshotAssertion
 
+# ``.`` is excluded because pathlib collapses it, which would desynchronise
+# the generated component count from ``Path.parts``.
 _PATH_COMPONENT = st.text(
     alphabet=st.characters(blacklist_characters="/\\\x00"),
     min_size=1,
-)
+).filter(lambda component: component != ".")
 _URI_SCHEME = st.text(
     alphabet=st.characters(
         whitelist_categories=("Ll", "Lu", "Nd"),

--- a/tests/unit/test_dependency_sections.py
+++ b/tests/unit/test_dependency_sections.py
@@ -1,0 +1,84 @@
+"""Tests for the canonical Cargo dependency-section vocabulary.
+
+Issue #103: the section names live once in
+:data:`lading.commands.bump_toml.DEPENDENCY_SECTIONS`; the kind mapping in
+``bump`` and the snippet rewriting in ``bump_docs`` must stay in agreement
+with it.
+"""
+
+from __future__ import annotations
+
+import typing as typ
+
+import hypothesis.strategies as st
+from hypothesis import given, settings
+from tomlkit import parse as parse_toml
+
+from lading.commands import bump, bump_docs, bump_toml
+
+if typ.TYPE_CHECKING:
+    from syrupy.assertion import SnapshotAssertion
+
+_DECOY_SECTIONS = ("decoy-dependencies", "tooling")
+
+
+def test_kind_mapping_agrees_with_canonical_sections() -> None:
+    """Every mapped section is canonical and every canonical section is mapped."""
+    mapped = set(bump._DEPENDENCY_SECTION_BY_KIND.values())
+
+    assert mapped == set(bump_toml.DEPENDENCY_SECTIONS)
+
+
+def test_workspace_dependency_sections_use_canonical_vocabulary() -> None:
+    """The workspace manifest update targets exactly the canonical sections."""
+    sections = bump._workspace_dependency_sections(["alpha", "beta"])
+
+    assert tuple(sections) == bump_toml.DEPENDENCY_SECTIONS
+    assert all(names == {"alpha", "beta"} for names in sections.values())
+
+
+def _render_manifest(sections: tuple[str, ...]) -> str:
+    """Render a manifest with one pinned dependency per requested section."""
+    blocks = [
+        f'[{section}]\nalpha = "1.0.0"\nother = "0.9.0"\n' for section in sections
+    ]
+    return "\n".join(blocks)
+
+
+@settings(max_examples=40, deadline=None)
+@given(
+    present=st.sets(st.sampled_from(bump_toml.DEPENDENCY_SECTIONS)),
+    decoys=st.sets(st.sampled_from(_DECOY_SECTIONS)),
+)
+def test_snippet_rewrite_visits_exactly_canonical_sections(
+    present: set[str], decoys: set[str]
+) -> None:
+    """Rewriting updates targets in canonical sections and nothing else."""
+    ordered = tuple(
+        section
+        for section in (*bump_toml.DEPENDENCY_SECTIONS, *_DECOY_SECTIONS)
+        if section in present | decoys
+    )
+    document = parse_toml(_render_manifest(ordered))
+
+    changed = bump_docs.update_toml_snippet_dependencies(document, ("alpha",), "2.0.0")
+
+    assert changed is bool(present)
+    rendered = document.as_string()
+    for section in ordered:
+        table = document[section]
+        expected_alpha = "2.0.0" if section in present else "1.0.0"
+        assert table["alpha"] == expected_alpha, rendered
+        # Non-target crates are never rewritten, canonical section or not.
+        assert table["other"] == "0.9.0", rendered
+
+
+def test_multi_section_manifest_rewrite_snapshot(
+    snapshot: SnapshotAssertion,
+) -> None:
+    """The rewritten multi-section manifest output is locked by snapshot."""
+    manifest = _render_manifest(bump_toml.DEPENDENCY_SECTIONS + _DECOY_SECTIONS)
+    document = parse_toml(manifest)
+
+    assert bump_docs.update_toml_snippet_dependencies(document, ("alpha",), "2.0.0")
+    assert snapshot == document.as_string()


### PR DESCRIPTION
## Summary

Closes #103

- Define `DEPENDENCY_SECTIONS` once in `lading/commands/bump_toml.py` — the canonical Cargo dependency-section vocabulary.
- Derive all three former hardcoded sites from it: `bump_docs.update_toml_snippet_dependencies`, `bump._workspace_dependency_sections`, and `bump._DEPENDENCY_SECTION_BY_KIND` (now unpacked from the constant so the kind→section mapping cannot drift).
- Document the canonical home in `docs/developers-guide.md`.
- Also fixes a pre-existing flaky Hypothesis test in `tests/unit/test_bump_readme.py` (separate commit): `parts=['.']` collapses to zero `Path.parts`, tripping an auxiliary assertion.

## Testing

- New `tests/unit/test_dependency_sections.py`: mapping/list consistency assertions, a Hypothesis property test that snippet rewriting visits exactly the canonical sections (decoy sections untouched), and a syrupy snapshot of a rewritten multi-section manifest.
- `make check-fmt`, `make lint`, `make typecheck`, and `make test` (559 passed) all green.
- `coderabbit review --agent`: 0 findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Centralise the definition of Cargo dependency-section names and ensure all related logic and tests derive from a single canonical source.

New Features:
- Introduce a canonical DEPENDENCY_SECTIONS constant for Cargo dependency-section names used across bump and documentation update logic.

Bug Fixes:
- Fix a flaky Hypothesis-based README bump test by avoiding path components that collapse to an empty Path.parts sequence.

Enhancements:
- Refactor dependency kind-to-section mapping and workspace dependency section computation to derive from the canonical dependency-section vocabulary.
- Update TOML snippet dependency rewriting to iterate over the canonical dependency-section list instead of hardcoded literals.

Documentation:
- Document the canonical Cargo dependency-section vocabulary and its required usage in the developer guide.

Tests:
- Add tests to validate that dependency kind mappings and workspace dependency sections align with the canonical dependency-section list and that snippet rewriting only affects canonical sections, including a snapshot test of multi-section manifest rewriting.