### PR TITLE
Extract shared command-failure detail helpers (#102)

### DIFF
--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -451,8 +451,9 @@ convenience wrapper that derives the detail with `command_detail` and appends
 it with `append_detail` in one call.
 
 These are the canonical home for the `(stderr or stdout)` failure-detail idiom.
-Modules that render command failures (`lockfile`, `bump_lockfiles`,
-`publish_preflight`, `publish_index_check`, `workspace.metadata`) must call
+Modules that render command failures (`lading.commands.lockfile`,
+`lading.commands.bump_lockfiles`, `lading.commands.publish_preflight`,
+`lading.commands.publish_index_check`, `lading.workspace.metadata`) must call
 these helpers rather than re-implementing the idiom inline.
 
 ### Shared message helpers

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -439,8 +439,16 @@ for the entire handler call: the active `PublishPlan`, the
 stream for a failed command: stderr stripped of whitespace when non-empty,
 otherwise stdout stripped, otherwise the empty string.
 
-`with_detail(message, stdout, stderr, *, separator=": ") -> str` appends the
-command detail to `message` using `separator` only when detail is present.
+`append_detail(message, detail, *, separator=": ") -> str` appends an
+*already-derived* `detail` to `message` using `separator` only when `detail` is
+non-empty. Reach for it when the caller has already computed the detail (for
+example via `command_detail` to branch on its content) and must not derive it
+twice — `_verify_clean_working_tree` inspects the detail to decide whether to
+mention "is this a git repository?" before appending it.
+
+`with_detail(message, stdout, stderr, *, separator=": ") -> str` is the
+convenience wrapper that derives the detail with `command_detail` and appends
+it with `append_detail` in one call.
 
 These are the canonical home for the `(stderr or stdout)` failure-detail idiom.
 Modules that render command failures (`lockfile`, `bump_lockfiles`,

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -433,6 +433,20 @@ argument-count threshold.
 for the entire handler call: the active `PublishPlan`, the
 `_PublishExecutionOptions`, and `logger`.
 
+### Command-failure detail helpers (`lading.utils.process`)
+
+`command_detail(stdout, stderr) -> str` returns the most informative output
+stream for a failed command: stderr stripped of whitespace when non-empty,
+otherwise stdout stripped, otherwise the empty string.
+
+`with_detail(message, stdout, stderr, *, separator=": ") -> str` appends the
+command detail to `message` using `separator` only when detail is present.
+
+These are the canonical home for the `(stderr or stdout)` failure-detail idiom.
+Modules that render command failures (`lockfile`, `bump_lockfiles`,
+`publish_preflight`, `publish_index_check`, `workspace.metadata`) must call
+these helpers rather than re-implementing the idiom inline.
+
 ### Shared message helpers
 
 `_format_missing_dependency_failure(failure, *,`

--- a/lading/commands/bump_lockfiles.py
+++ b/lading/commands/bump_lockfiles.py
@@ -14,6 +14,7 @@ from pathlib import Path
 
 from lading.exceptions import LadingError
 from lading.runtime import CommandRunner, subprocess_runner
+from lading.utils.process import with_detail
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -144,10 +145,10 @@ def _run_workspace_lockfile_update(
         message = f"Cargo lockfile regeneration failed for {manifest_path}: {exc}"
         raise LockfileRegenerationError(message) from exc
     if exit_code != 0:
-        message = (
+        message = with_detail(
             "Cargo lockfile regeneration failed for "
-            f"{manifest_path} with exit code {exit_code}"
+            f"{manifest_path} with exit code {exit_code}",
+            stdout,
+            stderr,
         )
-        if detail := (stderr or stdout).strip():
-            message = f"{message}: {detail}"
         raise LockfileRegenerationError(message)

--- a/lading/commands/lockfile.py
+++ b/lading/commands/lockfile.py
@@ -35,7 +35,7 @@ import typing as typ
 from pathlib import Path
 
 from lading.exceptions import LadingError
-from lading.utils.process import command_detail, with_detail
+from lading.utils.process import append_detail, command_detail, with_detail
 
 if typ.TYPE_CHECKING:
     from lading.runtime import CommandRunner
@@ -77,10 +77,12 @@ def _handle_git_ls_files_failure(
             workspace_root,
         )
         return ()
+    # Unlike the other sites, git may exit non-zero with no output at all, so
+    # fall back to the status code before handing the detail to append_detail.
     fallback = f"git ls-files exited with status {exit_code}"
-    message = (
-        f"Failed to discover tracked Cargo.lock files in {workspace_root}: "
-        f"{detail or fallback}"
+    message = append_detail(
+        f"Failed to discover tracked Cargo.lock files in {workspace_root}",
+        detail or fallback,
     )
     raise LockfileDiscoveryError(message)
 

--- a/lading/commands/lockfile.py
+++ b/lading/commands/lockfile.py
@@ -35,6 +35,7 @@ import typing as typ
 from pathlib import Path
 
 from lading.exceptions import LadingError
+from lading.utils.process import command_detail, with_detail
 
 if typ.TYPE_CHECKING:
     from lading.runtime import CommandRunner
@@ -69,18 +70,18 @@ def _handle_git_ls_files_failure(
     """Return ``None`` for git success, or an empty result for git failure."""
     if exit_code == 0:
         return None
-    detail = (stderr or stdout).strip()
+    detail = command_detail(stdout, stderr)
     if "not a git repository" in detail.lower():
         LOGGER.warning(
             "Skipping Cargo.lock discovery because %s is not a git repository",
             workspace_root,
         )
         return ()
-    message = f"Failed to discover tracked Cargo.lock files in {workspace_root}"
-    if detail:
-        message = f"{message}: {detail}"
-    else:
-        message = f"{message}: git ls-files exited with status {exit_code}"
+    fallback = f"git ls-files exited with status {exit_code}"
+    message = (
+        f"Failed to discover tracked Cargo.lock files in {workspace_root}: "
+        f"{detail or fallback}"
+    )
     raise LockfileDiscoveryError(message)
 
 
@@ -191,10 +192,7 @@ def refresh_lockfile(
         cwd=manifest_path.parent,
     )
     if exit_code != 0:
-        detail = (stderr or stdout).strip()
-        message = f"Failed to refresh {lockfile_path}"
-        if detail:
-            message = f"{message}: {detail}"
+        message = with_detail(f"Failed to refresh {lockfile_path}", stdout, stderr)
         raise LockfileRefreshError(message)
     LOGGER.info("Refreshed %s", lockfile_path)
     return lockfile_path
@@ -232,7 +230,7 @@ def validate_lockfile_freshness(
         ),
         cwd=manifest_path.parent,
     )
-    detail = (stderr or stdout).strip()
+    detail = command_detail(stdout, stderr)
     is_fresh = exit_code == 0
     is_stale = _is_lockfile_stale_detail(detail)
     state = "fresh"

--- a/lading/commands/publish_index_check.py
+++ b/lading/commands/publish_index_check.py
@@ -14,6 +14,8 @@ import logging
 import re
 import typing as typ
 
+from lading.utils.process import with_detail
+
 if typ.TYPE_CHECKING:
     from lading.commands.publish import _PublishExecutionOptions
     from lading.commands.publish_plan import PublishPlan
@@ -102,13 +104,11 @@ def _format_cargo_failure_message(
     stable.
     """
     stdout, stderr = output
-    detail = (stderr or stdout).strip()
-    message = (
-        f"cargo {command} failed for crate {crate_name} with exit code {exit_code}"
+    return with_detail(
+        f"cargo {command} failed for crate {crate_name} with exit code {exit_code}",
+        stdout,
+        stderr,
     )
-    if detail:
-        message = f"{message}: {detail}"
-    return message
 
 
 def _raise_name_extraction_failure(

--- a/lading/commands/publish_preflight.py
+++ b/lading/commands/publish_preflight.py
@@ -40,6 +40,7 @@ from lading.commands.lockfile import (
 from lading.commands.publish_diagnostics import _append_compiletest_diagnostics
 from lading.commands.publish_errors import PublishPreflightError
 from lading.commands.publish_execution import _invoke
+from lading.utils.process import command_detail, with_detail
 
 if typ.TYPE_CHECKING:
     from lading.config import CompiletestExtern, LadingConfig
@@ -80,13 +81,14 @@ def _run_aux_build_commands(
     for command in commands:
         exit_code, stdout, stderr = runner(command, cwd=workspace_root, env=env)
         if exit_code != 0:
-            detail = (stderr or stdout).strip()
             rendered = " ".join(command)
-            message = (
-                f"Auxiliary build command failed with exit code {exit_code}: {rendered}"
+            message = with_detail(
+                f"Auxiliary build command failed with exit code {exit_code}: "
+                f"{rendered}",
+                stdout,
+                stderr,
+                separator="; ",
             )
-            if detail:
-                message = f"{message}; {detail}"
             LOGGER.error(message)
             raise PublishPreflightError(message)
 
@@ -319,14 +321,14 @@ def _verify_clean_working_tree(
         env=env,
     )
     if exit_code != 0:
-        detail = (stderr or stdout).strip()
-        message = (
+        detail = command_detail(stdout, stderr)
+        message = with_detail(
             "Failed to verify workspace state; is this a git repository?"
             if "not a git repository" in detail.lower()
-            else "Failed to verify workspace state with git status"
+            else "Failed to verify workspace state with git status",
+            stdout,
+            stderr,
         )
-        if detail:
-            message = f"{message}: {detail}"
         LOGGER.error(message)
         raise PublishPreflightError(message)
     if stdout.strip():
@@ -371,10 +373,11 @@ def _build_cargo_error_message(
     subcommand: str, exit_code: int, stdout: str, stderr: str
 ) -> str:
     """Return a consistent failure message for cargo pre-flight commands."""
-    message = f"Pre-flight cargo {subcommand} failed with exit code {exit_code}"
-    if detail := (stderr or stdout).strip():
-        message = f"{message}: {detail}"
-    return message
+    return with_detail(
+        f"Pre-flight cargo {subcommand} failed with exit code {exit_code}",
+        stdout,
+        stderr,
+    )
 
 
 __all__ = [

--- a/lading/commands/publish_preflight.py
+++ b/lading/commands/publish_preflight.py
@@ -40,7 +40,7 @@ from lading.commands.lockfile import (
 from lading.commands.publish_diagnostics import _append_compiletest_diagnostics
 from lading.commands.publish_errors import PublishPreflightError
 from lading.commands.publish_execution import _invoke
-from lading.utils.process import command_detail, with_detail
+from lading.utils.process import append_detail, command_detail, with_detail
 
 if typ.TYPE_CHECKING:
     from lading.config import CompiletestExtern, LadingConfig
@@ -321,14 +321,16 @@ def _verify_clean_working_tree(
         env=env,
     )
     if exit_code != 0:
+        # Derive the detail once: it is both inspected (to choose the base
+        # message) and appended, so re-deriving via with_detail would repeat
+        # command_detail's work.
         detail = command_detail(stdout, stderr)
-        message = with_detail(
+        base_message = (
             "Failed to verify workspace state; is this a git repository?"
             if "not a git repository" in detail.lower()
-            else "Failed to verify workspace state with git status",
-            stdout,
-            stderr,
+            else "Failed to verify workspace state with git status"
         )
+        message = append_detail(base_message, detail)
         LOGGER.error(message)
         raise PublishPreflightError(message)
     if stdout.strip():

--- a/lading/utils/process.py
+++ b/lading/utils/process.py
@@ -77,6 +77,19 @@ def command_detail(stdout: str, stderr: str) -> str:
     nothing. This is the canonical home for the idiom (issue #102) — call
     sites must not re-implement it.
 
+    Parameters
+    ----------
+    stdout : str
+        Captured standard-output stream of the failed command.
+    stderr : str
+        Captured standard-error stream of the failed command.
+
+    Returns
+    -------
+    str
+        Stripped ``stderr`` when non-empty, otherwise stripped ``stdout``,
+        otherwise the empty string.
+
     Examples
     --------
     >>> command_detail("out", "err")
@@ -96,6 +109,21 @@ def append_detail(message: str, detail: str, *, separator: str = ": ") -> str:
     :func:`command_detail`, for example to branch on its content) and wants to
     avoid deriving it twice. :func:`with_detail` is the convenience wrapper that
     derives the detail and appends it in a single call.
+
+    Parameters
+    ----------
+    message : str
+        Base failure message to which the detail is appended.
+    detail : str
+        Pre-derived detail string; appended verbatim only when non-empty.
+    separator : str, optional
+        String joining ``message`` and ``detail``. Defaults to ``": "``.
+
+    Returns
+    -------
+    str
+        ``message`` unchanged when ``detail`` is empty, otherwise
+        ``message`` joined to ``detail`` by ``separator``.
 
     Examples
     --------
@@ -117,6 +145,27 @@ def with_detail(
     separator: str = ": ",
 ) -> str:
     """Append command output detail to ``message`` when any is present.
+
+    Derives the detail with :func:`command_detail` and appends it with
+    :func:`append_detail`.
+
+    Parameters
+    ----------
+    message : str
+        Base failure message to which the detail is appended.
+    stdout : str
+        Captured standard-output stream of the failed command.
+    stderr : str
+        Captured standard-error stream of the failed command.
+    separator : str, optional
+        String joining ``message`` and the derived detail. Defaults to
+        ``": "``.
+
+    Returns
+    -------
+    str
+        ``message`` unchanged when neither stream yields detail, otherwise
+        ``message`` joined to the derived detail by ``separator``.
 
     Examples
     --------

--- a/lading/utils/process.py
+++ b/lading/utils/process.py
@@ -1,4 +1,33 @@
-"""Process execution helpers for :mod:`lading`."""
+"""Process execution helpers for :mod:`lading`.
+
+This module is the canonical home for the small idioms shared by every command
+that shells out to ``cargo`` or ``git`` and must report a failure to operators.
+It covers two concerns:
+
+* **Command rendering / logging** — :func:`format_command` and
+  :func:`log_command_invocation` produce a stable, shell-style representation of
+  a command for log output.
+* **Failure-detail formatting** — :func:`command_detail`,
+  :func:`append_detail`, and :func:`with_detail` collapse the
+  ``(stderr or stdout).strip()`` idiom into one place (issue #102) so every
+  call site renders the same operator-facing text.
+
+The failure-detail helpers form a small layer:
+
+* :func:`command_detail` picks the most informative stripped stream.
+* :func:`append_detail` joins an *already-derived* detail onto a message; use it
+  when the caller has computed the detail itself (for example to branch on its
+  content) and must not derive it twice.
+* :func:`with_detail` is the convenience wrapper that derives and appends in one
+  call.
+
+Dependent modules that render command failures —
+:mod:`lading.commands.lockfile`, :mod:`lading.commands.bump_lockfiles`,
+:mod:`lading.commands.publish_preflight`,
+:mod:`lading.commands.publish_index_check`, and
+:mod:`lading.workspace.metadata` — must call these helpers rather than
+re-implementing the idiom inline.
+"""
 
 from __future__ import annotations
 
@@ -60,6 +89,26 @@ def command_detail(stdout: str, stderr: str) -> str:
     return stderr.strip() or stdout.strip()
 
 
+def append_detail(message: str, detail: str, *, separator: str = ": ") -> str:
+    """Append an already-derived ``detail`` to ``message`` when non-empty.
+
+    Use this when the caller has already computed ``detail`` (typically via
+    :func:`command_detail`, for example to branch on its content) and wants to
+    avoid deriving it twice. :func:`with_detail` is the convenience wrapper that
+    derives the detail and appends it in a single call.
+
+    Examples
+    --------
+    >>> append_detail("Build failed", "boom")
+    'Build failed: boom'
+    >>> append_detail("Build failed", "")
+    'Build failed'
+    """
+    if not detail:
+        return message
+    return f"{message}{separator}{detail}"
+
+
 def with_detail(
     message: str,
     stdout: str,
@@ -76,13 +125,11 @@ def with_detail(
     >>> with_detail("Build failed", "", "")
     'Build failed'
     """
-    detail = command_detail(stdout, stderr)
-    if not detail:
-        return message
-    return f"{message}{separator}{detail}"
+    return append_detail(message, command_detail(stdout, stderr), separator=separator)
 
 
 __all__ = [
+    "append_detail",
     "command_detail",
     "format_command",
     "log_command_invocation",

--- a/lading/utils/process.py
+++ b/lading/utils/process.py
@@ -41,4 +41,50 @@ def log_command_invocation(
         logger.info("Running external command: %s (cwd=%s)", rendered, cwd)
 
 
-__all__ = ["format_command", "log_command_invocation"]
+def command_detail(stdout: str, stderr: str) -> str:
+    """Return the most informative stripped output stream for a failure.
+
+    ``stderr`` is preferred; ``stdout`` is the fallback when stderr strips to
+    nothing. This is the canonical home for the idiom (issue #102) — call
+    sites must not re-implement it.
+
+    Examples
+    --------
+    >>> command_detail("out", "err")
+    'err'
+    >>> command_detail("out", "  ")
+    'out'
+    >>> command_detail("", "")
+    ''
+    """
+    return stderr.strip() or stdout.strip()
+
+
+def with_detail(
+    message: str,
+    stdout: str,
+    stderr: str,
+    *,
+    separator: str = ": ",
+) -> str:
+    """Append command output detail to ``message`` when any is present.
+
+    Examples
+    --------
+    >>> with_detail("Build failed", "", "boom")
+    'Build failed: boom'
+    >>> with_detail("Build failed", "", "")
+    'Build failed'
+    """
+    detail = command_detail(stdout, stderr)
+    if not detail:
+        return message
+    return f"{message}{separator}{detail}"
+
+
+__all__ = [
+    "command_detail",
+    "format_command",
+    "log_command_invocation",
+    "with_detail",
+]

--- a/lading/workspace/metadata.py
+++ b/lading/workspace/metadata.py
@@ -16,6 +16,7 @@ from lading.runtime import (
     subprocess_runner,
 )
 from lading.utils import normalise_workspace_root
+from lading.utils.process import command_detail
 
 if typ.TYPE_CHECKING:  # pragma: no cover - import-time typing aids only
     from pathlib import Path
@@ -48,10 +49,8 @@ class CargoMetadataInvocationError(CargoMetadataError):
 
     def __init__(self, exit_code: int, stdout: str, stderr: str) -> None:
         """Summarise the failing invocation for the caller."""
-        message = (
-            stderr.strip()
-            or stdout.strip()
-            or f"cargo metadata exited with status {exit_code}"
+        message = command_detail(stdout, stderr) or (
+            f"cargo metadata exited with status {exit_code}"
         )
         super().__init__(message)
 

--- a/tests/unit/__snapshots__/test_command_failure_messages.ambr
+++ b/tests/unit/__snapshots__/test_command_failure_messages.ambr
@@ -1,28 +1,16 @@
 # serializer version: 1
-# name: test_cargo_metadata_invocation_message
+# name: test_cargo_metadata_invocation_message[status_fallback]
+  'cargo metadata exited with status 2'
+# ---
+# name: test_cargo_metadata_invocation_message[stderr_wins]
   'err'
 # ---
-# name: test_cargo_metadata_invocation_message.1
+# name: test_cargo_metadata_invocation_message[stdout_fallback]
   'out'
-# ---
-# name: test_cargo_metadata_invocation_message.2
-  'cargo metadata exited with status 2'
 # ---
 # name: test_lockfile_refresh_failure_message
   'Failed to refresh /ws/crates/alpha/Cargo.lock: error: registry offline'
 # ---
 # name: test_lockfile_regeneration_failure_message
   'Cargo lockfile regeneration failed for /ws/Cargo.toml with exit code 101: error: dependency conflict'
-# ---
-# name: test_preflight_cargo_failure_message
-  'Pre-flight cargo check failed with exit code 101: error: linker failed'
-# ---
-# name: test_preflight_cargo_failure_message.1
-  'Pre-flight cargo test failed with exit code 7'
-# ---
-# name: test_publish_cargo_failure_message
-  'cargo package failed for crate alpha with exit code 101: error: missing version'
-# ---
-# name: test_publish_cargo_failure_message.1
-  'cargo publish failed for crate beta with exit code 1: only stdout'
 # ---

--- a/tests/unit/__snapshots__/test_command_failure_messages.ambr
+++ b/tests/unit/__snapshots__/test_command_failure_messages.ambr
@@ -1,0 +1,28 @@
+# serializer version: 1
+# name: test_cargo_metadata_invocation_message
+  'err'
+# ---
+# name: test_cargo_metadata_invocation_message.1
+  'out'
+# ---
+# name: test_cargo_metadata_invocation_message.2
+  'cargo metadata exited with status 2'
+# ---
+# name: test_lockfile_refresh_failure_message
+  'Failed to refresh /ws/crates/alpha/Cargo.lock: error: registry offline'
+# ---
+# name: test_lockfile_regeneration_failure_message
+  'Cargo lockfile regeneration failed for /ws/Cargo.toml with exit code 101: error: dependency conflict'
+# ---
+# name: test_preflight_cargo_failure_message
+  'Pre-flight cargo check failed with exit code 101: error: linker failed'
+# ---
+# name: test_preflight_cargo_failure_message.1
+  'Pre-flight cargo test failed with exit code 7'
+# ---
+# name: test_publish_cargo_failure_message
+  'cargo package failed for crate alpha with exit code 101: error: missing version'
+# ---
+# name: test_publish_cargo_failure_message.1
+  'cargo publish failed for crate beta with exit code 1: only stdout'
+# ---

--- a/tests/unit/publish/__snapshots__/test_preflight_cargo_runner.ambr
+++ b/tests/unit/publish/__snapshots__/test_preflight_cargo_runner.ambr
@@ -1,0 +1,7 @@
+# serializer version: 1
+# name: test_run_cargo_preflight_failure_message_snapshot[check_with_detail]
+  'Pre-flight cargo check failed with exit code 101: error: linker failed'
+# ---
+# name: test_run_cargo_preflight_failure_message_snapshot[test_without_detail]
+  'Pre-flight cargo test failed with exit code 7'
+# ---

--- a/tests/unit/publish/test_preflight_cargo_runner.py
+++ b/tests/unit/publish/test_preflight_cargo_runner.py
@@ -45,19 +45,32 @@ def test_run_cargo_preflight_raises_on_failure(
     assert "boom" in message
 
 
+@dc.dataclass(frozen=True)
+class _PreflightFailureCase:
+    """Inputs for a single cargo-preflight failure-message snapshot."""
+
+    subcommand: typ.Literal["check", "test"]
+    exit_code: int
+    stderr: str
+
+
 @pytest.mark.parametrize(
-    ("subcommand", "exit_code", "stderr"),
+    "case",
     [
-        pytest.param("check", 101, "error: linker failed\n", id="check_with_detail"),
-        pytest.param("test", 7, "", id="test_without_detail"),
+        pytest.param(
+            _PreflightFailureCase("check", 101, "error: linker failed\n"),
+            id="check_with_detail",
+        ),
+        pytest.param(
+            _PreflightFailureCase("test", 7, ""),
+            id="test_without_detail",
+        ),
     ],
 )
 def test_run_cargo_preflight_failure_message_snapshot(
     tmp_path: Path,
     snapshot: SnapshotAssertion,
-    subcommand: typ.Literal["check", "test"],
-    exit_code: int,
-    stderr: str,
+    case: _PreflightFailureCase,
 ) -> None:
     """Pin the operator-facing message raised when cargo pre-flight fails.
 
@@ -72,12 +85,12 @@ def test_run_cargo_preflight_failure_message_snapshot(
         env: cabc.Mapping[str, str] | None = None,
     ) -> tuple[int, str, str]:
         del command, cwd, env
-        return exit_code, "", stderr
+        return case.exit_code, "", case.stderr
 
     with pytest.raises(publish.PublishPreflightError) as excinfo:
         publish._run_cargo_preflight(
             tmp_path,
-            subcommand,
+            case.subcommand,
             runner=failing_runner,
             options=publish._CargoPreflightOptions(extra_args=("--workspace",)),
         )

--- a/tests/unit/publish/test_preflight_cargo_runner.py
+++ b/tests/unit/publish/test_preflight_cargo_runner.py
@@ -13,6 +13,9 @@ from lading.commands import publish
 
 from .conftest import ORIGINAL_PREFLIGHT
 
+if typ.TYPE_CHECKING:
+    from syrupy.assertion import SnapshotAssertion
+
 
 def test_run_cargo_preflight_raises_on_failure(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
@@ -40,6 +43,46 @@ def test_run_cargo_preflight_raises_on_failure(
     message = str(excinfo.value)
     assert "cargo check" in message
     assert "boom" in message
+
+
+@pytest.mark.parametrize(
+    ("subcommand", "exit_code", "stderr"),
+    [
+        pytest.param("check", 101, "error: linker failed\n", id="check_with_detail"),
+        pytest.param("test", 7, "", id="test_without_detail"),
+    ],
+)
+def test_run_cargo_preflight_failure_message_snapshot(
+    tmp_path: Path,
+    snapshot: SnapshotAssertion,
+    subcommand: typ.Literal["check", "test"],
+    exit_code: int,
+    stderr: str,
+) -> None:
+    """Pin the operator-facing message raised when cargo pre-flight fails.
+
+    Issue #102 routed this message through ``lading.utils.process.with_detail``;
+    the snapshot guards against the extraction silently changing the text.
+    """
+
+    def failing_runner(
+        command: tuple[str, ...],
+        *,
+        cwd: Path | None = None,
+        env: cabc.Mapping[str, str] | None = None,
+    ) -> tuple[int, str, str]:
+        del command, cwd, env
+        return exit_code, "", stderr
+
+    with pytest.raises(publish.PublishPreflightError) as excinfo:
+        publish._run_cargo_preflight(
+            tmp_path,
+            subcommand,
+            runner=failing_runner,
+            options=publish._CargoPreflightOptions(extra_args=("--workspace",)),
+        )
+
+    assert str(excinfo.value) == snapshot()
 
 
 @dc.dataclass(frozen=True)

--- a/tests/unit/test_command_failure_messages.py
+++ b/tests/unit/test_command_failure_messages.py
@@ -1,8 +1,20 @@
 """Snapshot tests for operator-facing command-failure messages.
 
 Issue #102 collapsed the ``(stderr or stdout).strip()`` idiom into the shared
-``lading.utils.process`` helpers. These snapshots pin the rendered messages
-at each consuming boundary so the extraction cannot silently change text.
+``lading.utils.process`` helpers. These snapshots pin the rendered messages at
+each consuming boundary so the extraction cannot silently change operator-facing
+text.
+
+Every test drives a *public* command entry point with an injected failing
+runner, so the message flows through the real failure path rather than being
+read back from a formatting helper in isolation. The remaining two consumers of
+the shared helpers are snapshotted at their own functional boundaries:
+
+* the cargo pre-flight message in
+  ``tests/unit/publish/test_preflight_cargo_runner.py`` (driving
+  ``_run_cargo_preflight``), and
+* the package/publish message in ``tests/unit/publish/test_packaging.py``
+  (driving ``_package_crate``/``_publish_crate``).
 """
 
 from __future__ import annotations
@@ -12,9 +24,8 @@ from pathlib import Path
 
 import pytest
 
-from lading.commands import bump_lockfiles, lockfile, publish_index_check
-from lading.commands.publish_preflight import _build_cargo_error_message
-from lading.workspace.metadata import CargoMetadataInvocationError
+from lading.commands import bump_lockfiles, lockfile
+from lading.workspace import metadata
 
 if typ.TYPE_CHECKING:
     import collections.abc as cabc
@@ -40,26 +51,8 @@ def _failing_runner(
     return runner
 
 
-def test_preflight_cargo_failure_message(snapshot: SnapshotAssertion) -> None:
-    """Cargo pre-flight failures render the canonical detail suffix."""
-    assert snapshot == _build_cargo_error_message(
-        "check", 101, "", "error: linker failed\n"
-    )
-    assert snapshot == _build_cargo_error_message("test", 7, "", "")
-
-
-def test_publish_cargo_failure_message(snapshot: SnapshotAssertion) -> None:
-    """Package and publish failures render the canonical detail suffix."""
-    assert snapshot == publish_index_check._format_cargo_failure_message(
-        "package", "alpha", 101, ("stdout context", "error: missing version\n")
-    )
-    assert snapshot == publish_index_check._format_cargo_failure_message(
-        "publish", "beta", 1, ("only stdout\n", "   ")
-    )
-
-
 def test_lockfile_refresh_failure_message(snapshot: SnapshotAssertion) -> None:
-    """Lockfile refresh failures render the canonical detail suffix."""
+    """``refresh_lockfile`` renders the canonical detail suffix."""
     manifest = Path("/ws/crates/alpha/Cargo.toml")
     with pytest.raises(lockfile.LockfileRefreshError) as excinfo:
         lockfile.refresh_lockfile(
@@ -70,20 +63,32 @@ def test_lockfile_refresh_failure_message(snapshot: SnapshotAssertion) -> None:
 
 
 def test_lockfile_regeneration_failure_message(snapshot: SnapshotAssertion) -> None:
-    """Lockfile regeneration failures render the canonical detail suffix."""
-    manifest = Path("/ws/Cargo.toml")
+    """``regenerate_lockfiles`` renders the canonical detail suffix."""
     with pytest.raises(bump_lockfiles.LockfileRegenerationError) as excinfo:
-        bump_lockfiles._run_workspace_lockfile_update(
+        bump_lockfiles.regenerate_lockfiles(
             Path("/ws"),
-            manifest,
-            _failing_runner("", "error: dependency conflict\n"),
+            (),
+            runner=_failing_runner("", "error: dependency conflict\n"),
         )
 
     assert snapshot == str(excinfo.value)
 
 
-def test_cargo_metadata_invocation_message(snapshot: SnapshotAssertion) -> None:
-    """Metadata failures prefer stderr, then stdout, then the status."""
-    assert snapshot == str(CargoMetadataInvocationError(2, "out", "err"))
-    assert snapshot == str(CargoMetadataInvocationError(2, "out", "   "))
-    assert snapshot == str(CargoMetadataInvocationError(2, "", ""))
+@pytest.mark.parametrize(
+    ("stdout", "stderr"),
+    [
+        pytest.param("out", "err", id="stderr_wins"),
+        pytest.param("out", "   ", id="stdout_fallback"),
+        pytest.param("", "", id="status_fallback"),
+    ],
+)
+def test_cargo_metadata_invocation_message(
+    tmp_path: Path, snapshot: SnapshotAssertion, stdout: str, stderr: str
+) -> None:
+    """``load_cargo_metadata`` prefers stderr, then stdout, then the status."""
+    with pytest.raises(metadata.CargoMetadataInvocationError) as excinfo:
+        metadata.load_cargo_metadata(
+            tmp_path, runner=_failing_runner(stdout, stderr, exit_code=2)
+        )
+
+    assert snapshot == str(excinfo.value)

--- a/tests/unit/test_command_failure_messages.py
+++ b/tests/unit/test_command_failure_messages.py
@@ -1,0 +1,89 @@
+"""Snapshot tests for operator-facing command-failure messages.
+
+Issue #102 collapsed the ``(stderr or stdout).strip()`` idiom into the shared
+``lading.utils.process`` helpers. These snapshots pin the rendered messages
+at each consuming boundary so the extraction cannot silently change text.
+"""
+
+from __future__ import annotations
+
+import typing as typ
+from pathlib import Path
+
+import pytest
+
+from lading.commands import bump_lockfiles, lockfile, publish_index_check
+from lading.commands.publish_preflight import _build_cargo_error_message
+from lading.workspace.metadata import CargoMetadataInvocationError
+
+if typ.TYPE_CHECKING:
+    import collections.abc as cabc
+
+    from syrupy.assertion import SnapshotAssertion
+
+
+def _failing_runner(
+    stdout: str, stderr: str, exit_code: int = 101
+) -> cabc.Callable[..., tuple[int, str, str]]:
+    """Return a stub runner that always fails with the supplied output."""
+
+    def runner(
+        command: cabc.Sequence[str],
+        *,
+        cwd: Path | None = None,
+        env: cabc.Mapping[str, str] | None = None,
+        echo_stdout: bool = True,
+    ) -> tuple[int, str, str]:
+        del command, cwd, env, echo_stdout
+        return exit_code, stdout, stderr
+
+    return runner
+
+
+def test_preflight_cargo_failure_message(snapshot: SnapshotAssertion) -> None:
+    """Cargo pre-flight failures render the canonical detail suffix."""
+    assert snapshot == _build_cargo_error_message(
+        "check", 101, "", "error: linker failed\n"
+    )
+    assert snapshot == _build_cargo_error_message("test", 7, "", "")
+
+
+def test_publish_cargo_failure_message(snapshot: SnapshotAssertion) -> None:
+    """Package and publish failures render the canonical detail suffix."""
+    assert snapshot == publish_index_check._format_cargo_failure_message(
+        "package", "alpha", 101, ("stdout context", "error: missing version\n")
+    )
+    assert snapshot == publish_index_check._format_cargo_failure_message(
+        "publish", "beta", 1, ("only stdout\n", "   ")
+    )
+
+
+def test_lockfile_refresh_failure_message(snapshot: SnapshotAssertion) -> None:
+    """Lockfile refresh failures render the canonical detail suffix."""
+    manifest = Path("/ws/crates/alpha/Cargo.toml")
+    with pytest.raises(lockfile.LockfileRefreshError) as excinfo:
+        lockfile.refresh_lockfile(
+            manifest, _failing_runner("", "error: registry offline\n")
+        )
+
+    assert snapshot == str(excinfo.value)
+
+
+def test_lockfile_regeneration_failure_message(snapshot: SnapshotAssertion) -> None:
+    """Lockfile regeneration failures render the canonical detail suffix."""
+    manifest = Path("/ws/Cargo.toml")
+    with pytest.raises(bump_lockfiles.LockfileRegenerationError) as excinfo:
+        bump_lockfiles._run_workspace_lockfile_update(
+            Path("/ws"),
+            manifest,
+            _failing_runner("", "error: dependency conflict\n"),
+        )
+
+    assert snapshot == str(excinfo.value)
+
+
+def test_cargo_metadata_invocation_message(snapshot: SnapshotAssertion) -> None:
+    """Metadata failures prefer stderr, then stdout, then the status."""
+    assert snapshot == str(CargoMetadataInvocationError(2, "out", "err"))
+    assert snapshot == str(CargoMetadataInvocationError(2, "out", "   "))
+    assert snapshot == str(CargoMetadataInvocationError(2, "", ""))

--- a/tests/unit/utils/test_process.py
+++ b/tests/unit/utils/test_process.py
@@ -5,6 +5,9 @@ from __future__ import annotations
 import logging
 import typing as typ
 
+import hypothesis.strategies as st
+from hypothesis import given
+
 from lading.utils import process
 
 if typ.TYPE_CHECKING:
@@ -97,3 +100,46 @@ def test_log_command_invocation_flags_empty_command() -> None:
         and "empty command sequence" in record.getMessage()
         for record in warning_handler.records
     )
+
+
+# ---------------------------------------------------------------------------
+# command_detail / with_detail (issue #102)
+# ---------------------------------------------------------------------------
+
+_output_text = st.text(
+    alphabet=st.characters(blacklist_categories=("Cs",)), max_size=40
+)
+
+
+@given(stdout=_output_text, stderr=_output_text)
+def test_command_detail_prefers_stderr_then_stdout(stdout: str, stderr: str) -> None:
+    """Prefer stripped stderr; fall back to stripped stdout."""
+    detail = process.command_detail(stdout, stderr)
+
+    if stderr.strip():
+        assert detail == stderr.strip()
+    elif stdout.strip():
+        assert detail == stdout.strip()
+    else:
+        assert detail == ""
+    assert detail == detail.strip()
+
+
+@given(stdout=_output_text, stderr=_output_text)
+def test_with_detail_appends_only_when_detail_present(stdout: str, stderr: str) -> None:
+    """The suffix appears exactly when stripped output exists."""
+    message = "Build failed"
+    rendered = process.with_detail(message, stdout, stderr)
+
+    detail = process.command_detail(stdout, stderr)
+    if detail:
+        assert rendered == f"{message}: {detail}"
+    else:
+        assert rendered == message
+
+
+def test_with_detail_supports_custom_separator() -> None:
+    """A custom separator joins the message and detail."""
+    rendered = process.with_detail("Failed", "", "boom", separator="; ")
+
+    assert rendered == "Failed; boom"

--- a/tests/unit/utils/test_process.py
+++ b/tests/unit/utils/test_process.py
@@ -125,6 +125,33 @@ def test_command_detail_prefers_stderr_then_stdout(stdout: str, stderr: str) -> 
     assert detail == detail.strip()
 
 
+@given(detail=_output_text)
+def test_append_detail_appends_only_when_detail_present(detail: str) -> None:
+    """A pre-derived detail is appended verbatim only when it is non-empty."""
+    message = "Build failed"
+    rendered = process.append_detail(message, detail)
+
+    if detail:
+        assert rendered == f"{message}: {detail}"
+    else:
+        assert rendered == message
+
+
+def test_append_detail_matches_with_detail() -> None:
+    """``with_detail`` is the derive-then-append wrapper over ``append_detail``."""
+    stdout, stderr = "  ", "boom\n"
+    detail = process.command_detail(stdout, stderr)
+
+    assert process.with_detail("Failed", stdout, stderr) == process.append_detail(
+        "Failed", detail
+    )
+
+
+def test_append_detail_supports_custom_separator() -> None:
+    """A custom separator joins the message and pre-derived detail."""
+    assert process.append_detail("Failed", "boom", separator="; ") == "Failed; boom"
+
+
 @given(stdout=_output_text, stderr=_output_text)
 def test_with_detail_appends_only_when_detail_present(stdout: str, stderr: str) -> None:
     """The suffix appears exactly when stripped output exists."""


### PR DESCRIPTION
## Summary

Closes #102

- Add `command_detail(stdout, stderr)` and `with_detail(message, stdout, stderr, *, separator=": ")` to `lading/utils/process.py` — the canonical home for the command-failure detail idiom.
- Convert all duplicated sites: `lockfile.py` (3×), `publish_preflight.py` (3×), `publish_index_check.py`, `bump_lockfiles.py`, and `workspace/metadata.py`. No inline `(stderr or stdout).strip()` remains.
- Semantics: strip before choosing (matching `metadata.py`'s previous behaviour) — a whitespace-only stderr now falls back to stdout rather than yielding an empty detail. `with_detail` accepts a separator so the auxiliary-build site keeps its `"; "` join.
- Document the helpers in `docs/developers-guide.md`.

## Testing

- Hypothesis property tests over `(stdout, stderr)` pairs: stderr wins when non-empty after strip, stdout is the fallback, no suffix when both strip empty, output always stripped.
- New `tests/unit/test_command_failure_messages.py` snapshots the rendered failure messages at each consuming boundary (cargo preflight, package/publish, lockfile refresh/regeneration, cargo metadata) so the extraction cannot silently change operator-facing text.
- `make check-fmt`, `make lint`, `make typecheck`, and `make test` (563 passed) all green.
- `coderabbit review --agent`: 0 findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Centralize command-failure detail formatting in shared helpers and update all call sites to use them while preserving operator-facing messages.

Enhancements:
- Introduce shared process helpers for deriving and appending command output details from stdout/stderr, and export them from the process utilities module.
- Refactor command and lockfile-related commands to use the shared helpers for consistent failure messages and slightly improved stderr/stdout selection semantics.
- Add snapshot coverage to pin operator-facing failure messages across commands and cargo metadata invocation behavior.

Documentation:
- Document the new command-failure detail helpers and their required usage in the developer guide.

Tests:
- Add Hypothesis-based property tests for the command detail helpers and snapshot tests for command-failure messages to guard against regressions.