### PR TITLE
Raise bump-domain error for README transposition failures (#100)

### DIFF
--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -256,8 +256,14 @@ area so existing handling remains precise:
 | `LockfileRefreshError`      | `lading.commands.lockfile`         | Raised when `cargo generate-lockfile` fails.                                                    |
 | `LockfileRegenerationError` | `lading.commands.bump_lockfiles`   | Raised when configured bump lockfile manifests are invalid or `cargo update --workspace` fails. |
 | `PublishPlanError`          | `lading.commands.publish_plan`     | Raised when a publish plan cannot be constructed.                                               |
+| `ReadmeTranspositionError`  | `lading.commands.bump_readme`      | Raised when the workspace README cannot be transposed into a crate during `lading bump`.        |
 | `PublishPreparationError`   | `lading.commands.publish_manifest` | Raised when staged publish manifests or workspace assets cannot be prepared.                    |
 | `PublishPreflightError`     | `lading.commands.publish_errors`   | Raised for local publish validation and pre-flight failures.                                    |
+
+Domain ownership: README transposition failures during `lading bump` are owned
+by the bump domain (`ReadmeTranspositionError`); publish staging failures are
+owned by the publish domain (`PublishPreparationError`). Bump modules must not
+import publish-domain error types for unrelated conditions, and vice versa.
 
 Reuse plan:
 

--- a/lading/commands/bump.py
+++ b/lading/commands/bump.py
@@ -10,7 +10,6 @@ import typing as typ
 
 from lading import config as config_module
 from lading.commands import bump_docs, bump_lockfiles, bump_readme, bump_toml
-from lading.commands.publish_manifest import PublishPreparationError
 from lading.utils import normalise_workspace_root
 
 if typ.TYPE_CHECKING:
@@ -298,7 +297,7 @@ def _process_readme_transposition(context: _BumpContext, *, dry_run: bool) -> se
                 dry_run=dry_run,
                 _source_text=cached_text,
             )
-        except PublishPreparationError:
+        except bump_readme.ReadmeTranspositionError:
             _log.error("README transposition failed for crate %r", crate.name)
             raise
         if changed_path is not None:

--- a/lading/commands/bump_readme.py
+++ b/lading/commands/bump_readme.py
@@ -155,16 +155,14 @@ def _load_source_text(source_readme: Path, _source_text: str | None) -> str:
     Raises ``ReadmeTranspositionError`` when the file is absent and no
     pre-loaded text was supplied.
     """
+    if _source_text is not None:
+        return _source_text
     if not source_readme.exists():
         message = (
             "Workspace README.md is required by crates that set readme.workspace = true"
         )
         raise ReadmeTranspositionError(message)
-    return (
-        _source_text
-        if _source_text is not None
-        else source_readme.read_text(encoding="utf-8")
-    )
+    return source_readme.read_text(encoding="utf-8")
 
 
 def _resolve_crate_relative_path(workspace_root: Path, crate: WorkspaceCrate) -> Path:

--- a/lading/commands/bump_readme.py
+++ b/lading/commands/bump_readme.py
@@ -24,7 +24,7 @@ from pathlib import Path
 from urllib.parse import urlparse
 
 from lading.commands import bump_toml
-from lading.commands.publish_manifest import PublishPreparationError
+from lading.exceptions import LadingError
 
 _log = logging.getLogger(__name__)
 
@@ -32,6 +32,15 @@ if typ.TYPE_CHECKING:
     from lading.workspace import WorkspaceCrate
 else:  # pragma: no cover - provide runtime placeholders for type checking imports
     WorkspaceCrate = typ.Any
+
+
+class ReadmeTranspositionError(LadingError):
+    """Raised when the workspace README cannot be transposed into a crate.
+
+    This is the bump-domain error for README adoption failures (issue #100);
+    publish staging failures use ``PublishPreparationError`` instead.
+    """
+
 
 _MARKDOWN_LINK_TARGET: typ.Final[re.Pattern[str]] = re.compile(
     r"(!?\[[^\]]*]\()([^\s)]*)([^)]*\))"
@@ -143,14 +152,14 @@ def _rewrite_links_outside_code(
 def _load_source_text(source_readme: Path, _source_text: str | None) -> str:
     """Read and return the workspace README text.
 
-    Raises ``PublishPreparationError`` when the file is absent and no
+    Raises ``ReadmeTranspositionError`` when the file is absent and no
     pre-loaded text was supplied.
     """
     if not source_readme.exists():
         message = (
             "Workspace README.md is required by crates that set readme.workspace = true"
         )
-        raise PublishPreparationError(message)
+        raise ReadmeTranspositionError(message)
     return (
         _source_text
         if _source_text is not None
@@ -161,7 +170,7 @@ def _load_source_text(source_readme: Path, _source_text: str | None) -> str:
 def _resolve_crate_relative_path(workspace_root: Path, crate: WorkspaceCrate) -> Path:
     """Return the crate path relative to the workspace root.
 
-    Raises ``PublishPreparationError`` when the crate lies outside the
+    Raises ``ReadmeTranspositionError`` when the crate lies outside the
     workspace.
     """
     try:
@@ -171,7 +180,7 @@ def _resolve_crate_relative_path(workspace_root: Path, crate: WorkspaceCrate) ->
             f"Crate {crate.name!r} is outside the workspace root; "
             "cannot transpose README"
         )
-        raise PublishPreparationError(message) from exc
+        raise ReadmeTranspositionError(message) from exc
 
 
 def _write_or_skip_readme(
@@ -229,7 +238,7 @@ def transpose_readme_to_crate(
 
     Raises
     ------
-    PublishPreparationError
+    ReadmeTranspositionError
         Raised when the workspace README is required but missing, or when the
         crate root is outside the workspace.
 

--- a/tests/unit/__snapshots__/test_bump_readme.ambr
+++ b/tests/unit/__snapshots__/test_bump_readme.ambr
@@ -1,0 +1,7 @@
+# serializer version: 1
+# name: test_transpose_readme_to_crate_rejects_external_crate_root
+  "Crate 'alpha' is outside the workspace root; cannot transpose README"
+# ---
+# name: test_transpose_readme_to_crate_requires_workspace_readme
+  'Workspace README.md is required by crates that set readme.workspace = true'
+# ---

--- a/tests/unit/test_bump_readme.py
+++ b/tests/unit/test_bump_readme.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import typing as typ
 from pathlib import Path
 
 import pytest
@@ -9,8 +10,11 @@ from hypothesis import given, settings
 from hypothesis import strategies as st
 
 from lading.commands import bump_readme
-from lading.commands.publish_manifest import PublishPreparationError
+from lading.commands.bump_readme import ReadmeTranspositionError
 from lading.workspace import WorkspaceCrate
+
+if typ.TYPE_CHECKING:
+    from syrupy.assertion import SnapshotAssertion
 
 _PATH_COMPONENT = st.text(
     alphabet=st.characters(blacklist_characters="/\\\x00"),
@@ -187,23 +191,29 @@ def test_transpose_readme_to_crate_skips_matching_target(tmp_path: Path) -> None
 
 def test_transpose_readme_to_crate_requires_workspace_readme(
     tmp_path: Path,
+    snapshot: SnapshotAssertion,
 ) -> None:
-    """Missing workspace README is reported through the preparation error type."""
+    """Missing workspace README raises the bump-domain transposition error."""
     crate = _make_crate(tmp_path)
 
-    with pytest.raises(PublishPreparationError, match=r"Workspace README\.md"):
+    with pytest.raises(ReadmeTranspositionError) as excinfo:
         bump_readme.transpose_readme_to_crate(tmp_path, crate, dry_run=False)
+
+    assert snapshot == str(excinfo.value)
 
 
 def test_transpose_readme_to_crate_rejects_external_crate_root(
     tmp_path: Path,
+    snapshot: SnapshotAssertion,
 ) -> None:
     """Crate roots outside the workspace cannot receive transposed READMEs."""
     crate = _make_crate(tmp_path.parent, f"{tmp_path.name}-external")
     (tmp_path / "README.md").write_text("# Project\n", encoding="utf-8")
 
-    with pytest.raises(PublishPreparationError, match=r"outside the workspace root"):
+    with pytest.raises(ReadmeTranspositionError) as excinfo:
         bump_readme.transpose_readme_to_crate(tmp_path, crate, dry_run=False)
+
+    assert snapshot == str(excinfo.value)
 
 
 @given(parts=st.lists(_PATH_COMPONENT, min_size=1, max_size=8))


### PR DESCRIPTION
## Summary

Closes #100

- Introduce `ReadmeTranspositionError(LadingError)` in `lading/commands/bump_readme.py` — the module that owns README adoption — and raise it on both failure paths (missing workspace README; crate outside the workspace root).
- `bump.py` no longer imports `PublishPreparationError` (or any publish-domain error type); the publish staging paths keep `PublishPreparationError` untouched.
- Document the error taxonomy and the bump/publish domain-ownership rule in `docs/developers-guide.md` (exception-hierarchy table extended).

## Testing

- Transposition failure tests assert the new bump-domain error on both paths.
- Both user-facing messages are pinned with syrupy snapshots so the rename is a deliberate, reviewed change.
- `make check-fmt`, `make lint`, `make typecheck`, and `make test` (555 passed) all green.
- `coderabbit review --agent`: 0 findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Introduce a bump-domain error for README transposition failures and align error handling, tests, and documentation with the updated error taxonomy.

New Features:
- Add a dedicated ReadmeTranspositionError for README adoption failures during lading bump.

Enhancements:
- Route README transposition failures in bump processing through the new ReadmeTranspositionError instead of publish-domain errors.
- Clarify error-domain ownership for bump vs. publish operations in the developer guide, including the exception hierarchy table.

Tests:
- Extend README transposition tests to assert the new error type and snapshot user-facing error messages.