### PR TITLE
Snapshot the already-published warning in _handle_publish_result (#73)

### DIFF
--- a/tests/unit/publish/__snapshots__/test_snapshot_messages.ambr
+++ b/tests/unit/publish/__snapshots__/test_snapshot_messages.ambr
@@ -1,4 +1,26 @@
 # serializer version: 1
+# name: test_already_published_warning_snapshot[index-exists]
+  tuple(
+    tuple(
+      'Crate %s @ %s is already published; skipping',
+      tuple(
+        'beta',
+        '0.1.0',
+      ),
+    ),
+  )
+# ---
+# name: test_already_published_warning_snapshot[uploaded]
+  tuple(
+    tuple(
+      'Crate %s @ %s is already published; skipping',
+      tuple(
+        'beta',
+        '0.1.0',
+      ),
+    ),
+  )
+# ---
 # name: test_index_missing_in_plan_downgrade_snapshot[warning]
   tuple(
     tuple(

--- a/tests/unit/publish/test_snapshot_messages.py
+++ b/tests/unit/publish/test_snapshot_messages.py
@@ -340,3 +340,48 @@ def test_pipeline_info_log_snapshot(
     )
 
     assert _pipeline_info_records(caplog) == snapshot()
+
+
+@pytest.mark.parametrize(
+    "stderr_marker",
+    [
+        pytest.param("error: crate version `0.1.0` is already uploaded", id="uploaded"),
+        pytest.param(
+            "error: crate beta@0.1.0 already exists on crates.io index",
+            id="index-exists",
+        ),
+    ],
+)
+def test_already_published_warning_snapshot(
+    tmp_path: Path,
+    caplog: pytest.LogCaptureFixture,
+    snapshot: SnapshotAssertion,
+    stderr_marker: str,
+) -> None:
+    """The already-published warning format is locked by snapshot.
+
+    Issue #73: `_handle_publish_result` downgrades cargo registry exit code
+    101 with an already-published marker to a WARNING and continues; the
+    exact message was previously unconstrained.
+    """
+    caplog.set_level(logging.WARNING, logger="lading.commands.publish")
+    workspace_root = tmp_path / "workspace"
+    crates = make_dependency_chain(workspace_root)
+    plan = publish.plan_publication(
+        make_workspace(workspace_root, *crates), make_config()
+    )
+    beta = next(crate for crate in plan.publishable if crate.name == "beta")
+    invocation = publish._CargoInvocation(
+        crate_name="beta",
+        subcommand="publish",
+        output=(101, "", stderr_marker),
+    )
+
+    publish._handle_publish_result(
+        invocation,
+        beta,
+        plan,
+        publish._PublishExecutionOptions(live=False, allow_dirty=True),
+    )
+
+    assert _warning_records(caplog) == snapshot()

--- a/tests/unit/publish/test_snapshot_messages.py
+++ b/tests/unit/publish/test_snapshot_messages.py
@@ -371,17 +371,12 @@ def test_already_published_warning_snapshot(
         make_workspace(workspace_root, *crates), make_config()
     )
     beta = next(crate for crate in plan.publishable if crate.name == "beta")
-    invocation = publish._CargoInvocation(
-        crate_name="beta",
-        subcommand="publish",
-        output=(101, "", stderr_marker),
-    )
 
     publish._handle_publish_result(
-        invocation,
         beta,
-        plan,
-        publish._PublishExecutionOptions(live=False, allow_dirty=True),
+        (101, "", stderr_marker),
+        plan=plan,
+        options=publish._PublishExecutionOptions(live=False, allow_dirty=True),
     )
 
     assert _warning_records(caplog) == snapshot()


### PR DESCRIPTION
## Summary

Closes #73

- Add syrupy snapshot tests to `tests/unit/publish/test_snapshot_messages.py`, following the existing `_warning_records` pattern, for the already-published warning branch of `_handle_publish_result`.
- Both registry phrasings cargo emits are covered (version already uploaded; crate already exists on the crates.io index), locking in the exact WARNING record (`"Crate %s @ %s is already published; skipping"`) and its arguments.
- Review fix: the snapshot test previously constructed a non-existent `publish._CargoInvocation` and called `_handle_publish_result` with positional args in the wrong shape, so it raised before reaching the warning branch. It now calls `_handle_publish_result(beta, (101, "", stderr_marker), plan=plan, options=...)` directly, matching the current signature.

## Testing

- `make check-fmt`, `make lint`, `make typecheck`, and `make test` (681 passed, 64 snapshots) all green.

## References

- Lody session: https://lody.ai/leynos/sessions/4aa00bf2-4d09-40d6-92fe-4bab0afcf0c2

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Tests:
- Add syrupy snapshot tests to lock in the warning log record emitted when cargo reports a crate version as already published, covering multiple registry phrasing variants.
