### PR TITLE
Snapshot bump lockfile output and publish stale-lockfile errors (#81)

### DIFF
--- a/tests/unit/__snapshots__/test_lockfile_message_snapshots.ambr
+++ b/tests/unit/__snapshots__/test_lockfile_message_snapshots.ambr
@@ -1,0 +1,34 @@
+# serializer version: 1
+# name: test_bump_message_with_nested_lockfile
+  '''
+  Updated version to 1.2.3 in 1 manifest(s) and 2 lockfile(s):
+  - Cargo.toml
+  - Cargo.lock (lockfile)
+  - tests/ui_lints/Cargo.lock (lockfile)
+  '''
+# ---
+# name: test_bump_message_with_root_lockfile
+  '''
+  Updated version to 1.2.3 in 1 manifest(s) and 1 lockfile(s):
+  - Cargo.toml
+  - Cargo.lock (lockfile)
+  '''
+# ---
+# name: test_stale_lockfile_error_multiple
+  '''
+  Tracked Cargo.lock files are stale after manifest version changes.
+  This commonly happens after running `lading bump`; repair each stale lockfile directly:
+  - /ws/Cargo.lock
+    cargo generate-lockfile --manifest-path /ws/Cargo.toml
+  - /ws/tests/ui_lints/Cargo.lock
+    cargo generate-lockfile --manifest-path /ws/tests/ui_lints/Cargo.toml
+  '''
+# ---
+# name: test_stale_lockfile_error_single
+  '''
+  Tracked Cargo.lock files are stale after manifest version changes.
+  This commonly happens after running `lading bump`; repair each stale lockfile directly:
+  - /ws/Cargo.lock
+    cargo generate-lockfile --manifest-path /ws/Cargo.toml
+  '''
+# ---

--- a/tests/unit/__snapshots__/test_lockfile_message_snapshots.ambr
+++ b/tests/unit/__snapshots__/test_lockfile_message_snapshots.ambr
@@ -1,5 +1,5 @@
 # serializer version: 1
-# name: test_bump_message_with_nested_lockfile
+# name: TestBumpLockfileMessages.test_message[nested]
   '''
   Updated version to 1.2.3 in 1 manifest(s) and 2 lockfile(s):
   - Cargo.toml
@@ -7,14 +7,14 @@
   - tests/ui_lints/Cargo.lock (lockfile)
   '''
 # ---
-# name: test_bump_message_with_root_lockfile
+# name: TestBumpLockfileMessages.test_message[root]
   '''
   Updated version to 1.2.3 in 1 manifest(s) and 1 lockfile(s):
   - Cargo.toml
   - Cargo.lock (lockfile)
   '''
 # ---
-# name: test_stale_lockfile_error_multiple
+# name: TestStaleLockfileMessages.test_message[multiple]
   '''
   Tracked Cargo.lock files are stale after manifest version changes.
   This commonly happens after running `lading bump`; repair each stale lockfile directly:
@@ -24,7 +24,7 @@
     cargo generate-lockfile --manifest-path /ws/tests/ui_lints/Cargo.toml
   '''
 # ---
-# name: test_stale_lockfile_error_single
+# name: TestStaleLockfileMessages.test_message[single]
   '''
   Tracked Cargo.lock files are stale after manifest version changes.
   This commonly happens after running `lading bump`; repair each stale lockfile directly:

--- a/tests/unit/__snapshots__/test_lockfile_message_snapshots.ambr
+++ b/tests/unit/__snapshots__/test_lockfile_message_snapshots.ambr
@@ -17,7 +17,7 @@
 # name: TestStaleLockfileMessages.test_message[multiple]
   '''
   Tracked Cargo.lock files are stale after manifest version changes.
-  This commonly happens after running `lading bump`; repair each stale lockfile directly:
+  This can happen after manifest changes made without `lading bump`, or after running `lading bump --no-rebuild-lockfiles`; repair each stale lockfile directly:
   - /ws/Cargo.lock
     cargo generate-lockfile --manifest-path /ws/Cargo.toml
   - /ws/tests/ui_lints/Cargo.lock
@@ -27,7 +27,7 @@
 # name: TestStaleLockfileMessages.test_message[single]
   '''
   Tracked Cargo.lock files are stale after manifest version changes.
-  This commonly happens after running `lading bump`; repair each stale lockfile directly:
+  This can happen after manifest changes made without `lading bump`, or after running `lading bump --no-rebuild-lockfiles`; repair each stale lockfile directly:
   - /ws/Cargo.lock
     cargo generate-lockfile --manifest-path /ws/Cargo.toml
   '''

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -72,6 +72,11 @@ def disable_publish_preflight(monkeypatch: pytest.MonkeyPatch) -> None:
         lambda *_args, **_kwargs: None,
     )
 
+@pytest.fixture
+def enable_publish_preflight(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Restore publish pre-flight checks for public command integration tests."""
+    monkeypatch.setattr(publish, "_run_preflight_checks", _ORIGINAL_PREFLIGHT)
+
 
 @pytest.fixture(autouse=True)
 def stub_lockfile_regeneration(

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -19,6 +19,8 @@ from lading import config as config_module
 from lading.commands import bump, publish, publish_preflight
 from lading.workspace import WorkspaceCrate, WorkspaceDependency, WorkspaceGraph
 
+_ORIGINAL_PREFLIGHT = publish_preflight._run_preflight_checks
+
 # These modules drive ``bump.run`` to exercise manifest updates, documentation
 # rewriting, and the rebuild_lockfiles resolution logic -- none of which need
 # Cargo to actually build or regenerate lockfiles. The stub is scoped to them by
@@ -72,10 +74,15 @@ def disable_publish_preflight(monkeypatch: pytest.MonkeyPatch) -> None:
         lambda *_args, **_kwargs: None,
     )
 
+
 @pytest.fixture
 def enable_publish_preflight(monkeypatch: pytest.MonkeyPatch) -> None:
     """Restore publish pre-flight checks for public command integration tests."""
-    monkeypatch.setattr(publish, "_run_preflight_checks", _ORIGINAL_PREFLIGHT)
+    monkeypatch.setattr(
+        publish_preflight,
+        "_run_preflight_checks",
+        _ORIGINAL_PREFLIGHT,
+    )
 
 
 @pytest.fixture(autouse=True)

--- a/tests/unit/test_lockfile_message_snapshots.py
+++ b/tests/unit/test_lockfile_message_snapshots.py
@@ -1,0 +1,70 @@
+"""Snapshot tests for lockfile-related CLI output (issue #81).
+
+PR #75 introduced two text outputs that were previously verified only by
+substring matching: the ``(lockfile)`` suffix in ``lading bump`` result
+messages and the multi-line stale-lockfile error raised by
+``lading publish``. These snapshots lock in the exact formats.
+"""
+
+from __future__ import annotations
+
+import typing as typ
+from pathlib import Path
+
+from lading.commands import bump
+from lading.commands.publish_preflight import _build_stale_lockfile_message
+
+if typ.TYPE_CHECKING:
+    from syrupy.assertion import SnapshotAssertion
+
+_WORKSPACE_ROOT = Path("/ws")
+
+
+def _result_message(changes: bump.BumpChanges) -> str:
+    """Render the bump result message against the fixed workspace root."""
+    return bump._format_result_message(
+        changes,
+        "1.2.3",
+        dry_run=False,
+        workspace_root=_WORKSPACE_ROOT,
+    )
+
+
+def test_bump_message_with_root_lockfile(snapshot: SnapshotAssertion) -> None:
+    """A workspace-root Cargo.lock is listed with the (lockfile) suffix."""
+    changes = bump.BumpChanges(
+        manifests=(_WORKSPACE_ROOT / "Cargo.toml",),
+        lockfiles=(_WORKSPACE_ROOT / "Cargo.lock",),
+    )
+
+    assert snapshot == _result_message(changes)
+
+
+def test_bump_message_with_nested_lockfile(snapshot: SnapshotAssertion) -> None:
+    """A nested Cargo.lock renders relative to the workspace root."""
+    changes = bump.BumpChanges(
+        manifests=(_WORKSPACE_ROOT / "Cargo.toml",),
+        lockfiles=(
+            _WORKSPACE_ROOT / "Cargo.lock",
+            _WORKSPACE_ROOT / "tests" / "ui_lints" / "Cargo.lock",
+        ),
+    )
+
+    assert snapshot == _result_message(changes)
+
+
+def test_stale_lockfile_error_single(snapshot: SnapshotAssertion) -> None:
+    """A single stale lockfile lists one repair command."""
+    message = _build_stale_lockfile_message([_WORKSPACE_ROOT / "Cargo.lock"])
+
+    assert snapshot == message
+
+
+def test_stale_lockfile_error_multiple(snapshot: SnapshotAssertion) -> None:
+    """Multiple stale lockfiles each list their own repair command."""
+    message = _build_stale_lockfile_message([
+        _WORKSPACE_ROOT / "Cargo.lock",
+        _WORKSPACE_ROOT / "tests" / "ui_lints" / "Cargo.lock",
+    ])
+
+    assert snapshot == message

--- a/tests/unit/test_lockfile_message_snapshots.py
+++ b/tests/unit/test_lockfile_message_snapshots.py
@@ -16,7 +16,7 @@ from pathlib import Path
 import pytest
 
 from lading import config
-from lading.commands import bump, lockfile, publish, publish_preflight
+from lading.commands import bump, lockfile, publish
 from lading.workspace import WorkspaceGraph
 
 if typ.TYPE_CHECKING:
@@ -121,14 +121,14 @@ class TestStaleLockfileMessages:
     ) -> None:
         """The public publish command reports every stale lockfile repair."""
         monkeypatch.setattr(
-            publish_preflight,
+            lockfile.CargoLockfileInspectionRepository,
             "discover_tracked_lockfiles",
-            lambda _root, _runner: tuple(lockfiles),
+            lambda _repository, _root: tuple(lockfiles),
         )
         monkeypatch.setattr(
-            publish_preflight,
+            lockfile.CargoLockfileInspectionRepository,
             "validate_lockfile_freshness",
-            lambda _manifest, _runner: lockfile.LockfileFreshness(
+            lambda _repository, _manifest: lockfile.LockfileFreshness(
                 is_fresh=False,
                 is_stale=True,
                 detail="the lock file needs to be updated",

--- a/tests/unit/test_lockfile_message_snapshots.py
+++ b/tests/unit/test_lockfile_message_snapshots.py
@@ -3,50 +3,43 @@
 PR #75 introduced two text outputs that were previously verified only by
 substring matching: the ``(lockfile)`` suffix in ``lading bump`` result
 messages and the multi-line stale-lockfile error raised by
-``lading publish``. These snapshots lock in the exact formats.
+``lading publish``. These snapshots exercise the public command entry points
+and lock in the exact formats.
 """
 
 from __future__ import annotations
 
+import collections.abc as cabc
 import typing as typ
 from pathlib import Path
 
 import pytest
 
-from lading.commands import bump
-from lading.commands.publish_preflight import _build_stale_lockfile_message
+from lading import config
+from lading.commands import bump, lockfile, publish, publish_preflight
+from lading.workspace import WorkspaceGraph
 
 if typ.TYPE_CHECKING:
     from syrupy.assertion import SnapshotAssertion
 
-_WORKSPACE_ROOT = Path("/ws")
-
-
-def _result_message(changes: bump.BumpChanges) -> str:
-    """Render the bump result message against the fixed workspace root."""
-    return bump._format_result_message(
-        changes,
-        "1.2.3",
-        dry_run=False,
-        workspace_root=_WORKSPACE_ROOT,
-    )
+_SNAPSHOT_WORKSPACE_ROOT = Path("/ws")
 
 
 class TestBumpLockfileMessages:
     """Snapshot bump messages for root and nested lockfiles."""
 
     @pytest.mark.parametrize(
-        ("lockfiles", "scenario"),
+        ("lockfile_paths", "scenario"),
         [
             pytest.param(
-                (_WORKSPACE_ROOT / "Cargo.lock",),
+                (Path("Cargo.lock"),),
                 "root",
                 id="root",
             ),
             pytest.param(
                 (
-                    _WORKSPACE_ROOT / "Cargo.lock",
-                    _WORKSPACE_ROOT / "tests" / "ui_lints" / "Cargo.lock",
+                    Path("Cargo.lock"),
+                    Path("tests/ui_lints/Cargo.lock"),
                 ),
                 "nested",
                 id="nested",
@@ -55,21 +48,48 @@ class TestBumpLockfileMessages:
     )
     def test_message(
         self,
+        monkeypatch: pytest.MonkeyPatch,
         snapshot: SnapshotAssertion,
-        lockfiles: tuple[Path, ...],
+        tmp_path: Path,
+        lockfile_paths: tuple[Path, ...],
         scenario: str,
     ) -> None:
-        """Lockfiles render relative to the workspace root."""
-        changes = bump.BumpChanges(
-            manifests=(_WORKSPACE_ROOT / "Cargo.toml",),
-            lockfiles=lockfiles,
+        """The public bump command renders lockfiles relative to the workspace."""
+        (tmp_path / "Cargo.toml").write_text(
+            '[workspace]\nmembers = []\n\n[workspace.package]\nversion = "0.1.0"\n',
+            encoding="utf-8",
+        )
+        workspace = WorkspaceGraph(workspace_root=tmp_path, crates=())
+
+        def fake_regenerate_lockfiles(
+            workspace_root: Path,
+            lockfile_manifests: tuple[str, ...],
+            *,
+            runner: object | None = None,
+        ) -> tuple[Path, ...]:
+            del lockfile_manifests, runner
+            return tuple(workspace_root / path for path in lockfile_paths)
+
+        monkeypatch.setattr(
+            bump.bump_lockfiles,
+            "regenerate_lockfiles",
+            fake_regenerate_lockfiles,
         )
 
-        assert snapshot == _result_message(changes), (
-            f"{scenario} lockfile bump message changed"
+        message = bump.run(
+            tmp_path,
+            "1.2.3",
+            options=bump.BumpOptions(
+                rebuild_lockfiles=True,
+                configuration=config.LadingConfig(),
+                workspace=workspace,
+            ),
         )
 
+        assert snapshot == message, f"{scenario} lockfile bump message changed"
 
+
+@pytest.mark.usefixtures("enable_publish_preflight")
 class TestStaleLockfileMessages:
     """Snapshot stale-lockfile errors for one and multiple lockfiles."""
 
@@ -77,14 +97,14 @@ class TestStaleLockfileMessages:
         ("lockfiles", "scenario"),
         [
             pytest.param(
-                [_WORKSPACE_ROOT / "Cargo.lock"],
+                [_SNAPSHOT_WORKSPACE_ROOT / "Cargo.lock"],
                 "single",
                 id="single",
             ),
             pytest.param(
                 [
-                    _WORKSPACE_ROOT / "Cargo.lock",
-                    _WORKSPACE_ROOT / "tests" / "ui_lints" / "Cargo.lock",
+                    _SNAPSHOT_WORKSPACE_ROOT / "Cargo.lock",
+                    _SNAPSHOT_WORKSPACE_ROOT / "tests" / "ui_lints" / "Cargo.lock",
                 ],
                 "multiple",
                 id="multiple",
@@ -93,11 +113,46 @@ class TestStaleLockfileMessages:
     )
     def test_message(
         self,
+        monkeypatch: pytest.MonkeyPatch,
         snapshot: SnapshotAssertion,
+        tmp_path: Path,
         lockfiles: list[Path],
         scenario: str,
     ) -> None:
-        """Stale lockfiles each list their own repair command."""
-        message = _build_stale_lockfile_message(lockfiles)
+        """The public publish command reports every stale lockfile repair."""
+        monkeypatch.setattr(
+            publish_preflight,
+            "discover_tracked_lockfiles",
+            lambda _root, _runner: tuple(lockfiles),
+        )
+        monkeypatch.setattr(
+            publish_preflight,
+            "validate_lockfile_freshness",
+            lambda _manifest, _runner: lockfile.LockfileFreshness(
+                is_fresh=False,
+                is_stale=True,
+                detail="the lock file needs to be updated",
+            ),
+        )
 
-        assert snapshot == message, f"{scenario} stale-lockfile message changed"
+        def runner(
+            command: cabc.Sequence[str],
+            *,
+            cwd: Path | None = None,
+            env: cabc.Mapping[str, str] | None = None,
+        ) -> tuple[int, str, str]:
+            del command, cwd, env
+            return 0, "", ""
+
+        workspace = WorkspaceGraph(workspace_root=tmp_path, crates=())
+        with pytest.raises(publish.PublishPreflightError) as excinfo:
+            publish.run(
+                tmp_path,
+                config.LadingConfig(),
+                workspace,
+                options=publish.PublishOptions(command_runner=runner),
+            )
+
+        assert snapshot == str(excinfo.value), (
+            f"{scenario} stale-lockfile message changed"
+        )

--- a/tests/unit/test_lockfile_message_snapshots.py
+++ b/tests/unit/test_lockfile_message_snapshots.py
@@ -11,6 +11,8 @@ from __future__ import annotations
 import typing as typ
 from pathlib import Path
 
+import pytest
+
 from lading.commands import bump
 from lading.commands.publish_preflight import _build_stale_lockfile_message
 
@@ -30,41 +32,72 @@ def _result_message(changes: bump.BumpChanges) -> str:
     )
 
 
-def test_bump_message_with_root_lockfile(snapshot: SnapshotAssertion) -> None:
-    """A workspace-root Cargo.lock is listed with the (lockfile) suffix."""
-    changes = bump.BumpChanges(
-        manifests=(_WORKSPACE_ROOT / "Cargo.toml",),
-        lockfiles=(_WORKSPACE_ROOT / "Cargo.lock",),
+class TestBumpLockfileMessages:
+    """Snapshot bump messages for root and nested lockfiles."""
+
+    @pytest.mark.parametrize(
+        ("lockfiles", "scenario"),
+        [
+            pytest.param(
+                (_WORKSPACE_ROOT / "Cargo.lock",),
+                "root",
+                id="root",
+            ),
+            pytest.param(
+                (
+                    _WORKSPACE_ROOT / "Cargo.lock",
+                    _WORKSPACE_ROOT / "tests" / "ui_lints" / "Cargo.lock",
+                ),
+                "nested",
+                id="nested",
+            ),
+        ],
     )
+    def test_message(
+        self,
+        snapshot: SnapshotAssertion,
+        lockfiles: tuple[Path, ...],
+        scenario: str,
+    ) -> None:
+        """Lockfiles render relative to the workspace root."""
+        changes = bump.BumpChanges(
+            manifests=(_WORKSPACE_ROOT / "Cargo.toml",),
+            lockfiles=lockfiles,
+        )
 
-    assert snapshot == _result_message(changes)
+        assert snapshot == _result_message(changes), (
+            f"{scenario} lockfile bump message changed"
+        )
 
 
-def test_bump_message_with_nested_lockfile(snapshot: SnapshotAssertion) -> None:
-    """A nested Cargo.lock renders relative to the workspace root."""
-    changes = bump.BumpChanges(
-        manifests=(_WORKSPACE_ROOT / "Cargo.toml",),
-        lockfiles=(
-            _WORKSPACE_ROOT / "Cargo.lock",
-            _WORKSPACE_ROOT / "tests" / "ui_lints" / "Cargo.lock",
-        ),
+class TestStaleLockfileMessages:
+    """Snapshot stale-lockfile errors for one and multiple lockfiles."""
+
+    @pytest.mark.parametrize(
+        ("lockfiles", "scenario"),
+        [
+            pytest.param(
+                [_WORKSPACE_ROOT / "Cargo.lock"],
+                "single",
+                id="single",
+            ),
+            pytest.param(
+                [
+                    _WORKSPACE_ROOT / "Cargo.lock",
+                    _WORKSPACE_ROOT / "tests" / "ui_lints" / "Cargo.lock",
+                ],
+                "multiple",
+                id="multiple",
+            ),
+        ],
     )
+    def test_message(
+        self,
+        snapshot: SnapshotAssertion,
+        lockfiles: list[Path],
+        scenario: str,
+    ) -> None:
+        """Stale lockfiles each list their own repair command."""
+        message = _build_stale_lockfile_message(lockfiles)
 
-    assert snapshot == _result_message(changes)
-
-
-def test_stale_lockfile_error_single(snapshot: SnapshotAssertion) -> None:
-    """A single stale lockfile lists one repair command."""
-    message = _build_stale_lockfile_message([_WORKSPACE_ROOT / "Cargo.lock"])
-
-    assert snapshot == message
-
-
-def test_stale_lockfile_error_multiple(snapshot: SnapshotAssertion) -> None:
-    """Multiple stale lockfiles each list their own repair command."""
-    message = _build_stale_lockfile_message([
-        _WORKSPACE_ROOT / "Cargo.lock",
-        _WORKSPACE_ROOT / "tests" / "ui_lints" / "Cargo.lock",
-    ])
-
-    assert snapshot == message
+        assert snapshot == message, f"{scenario} stale-lockfile message changed"


### PR DESCRIPTION
## Summary

Closes [#81](https://github.com/leynos/lading/issues/81)

PR [#75](https://github.com/leynos/lading/pull/75) introduced text-based CLI output for lockfile operations that was verified only by substring matching. New `tests/unit/test_lockfile_message_snapshots.py` adds syrupy snapshot coverage for all four cases:

- Bump result message with a root `Cargo.lock` (`(lockfile)` suffix)
- Bump result message including a nested `tests/ui_lints/Cargo.lock`
- `PublishPreflightError` message for a single stale lockfile (with repair command)
- `PublishPreflightError` message for multiple stale lockfiles

Snapshots use a fixed `/ws` workspace root so they stay deterministic.

## Testing

- `make check-fmt`, `make lint`, `make typecheck`, and `make test` (559 passed) all green.
- `coderabbit review --agent`: 0 findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Add snapshot-based tests to lock in CLI output for lockfile bump and stale lockfile publish preflight messages.

Tests:

- Add syrupy snapshot tests covering bump result messages with root and nested Cargo.lock files.
- Add snapshot tests for publish preflight stale lockfile error messages for single and multiple lockfiles.

## References

- [Lody session](https://lody.ai/leynos/sessions/1e32f60b-0316-4194-9861-9027aa346343)
