### PR TITLE
Collapse bump result-message formatting into canonical bump_output (#95)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ PYLINT_PYPY_SHIM = git+https://github.com/leynos/pylint-pypy-shim.git@$(PYLINT_P
 PYLINT = $(UV) tool run --python $(PYLINT_PYTHON) --from '$(PYLINT_PYPY_SHIM)' pylint-pypy
 
 .PHONY: help all clean build build-release lint fmt check-fmt \
-	markdownlint nixie test typecheck $(TOOLS) $(VENV_TOOLS)
+	markdownlint nixie test typecheck crosshair $(TOOLS) $(VENV_TOOLS)
 
 .DEFAULT_GOAL := all
 
@@ -92,6 +92,16 @@ nixie: $(NIXIE) ## Validate Mermaid diagrams
 
 test: build $(UV) pytest ## Run tests
 	$(UV) run pytest -v
+
+# Model-check the bump_output pure-helper contracts (issue #95). Only the
+# string/count helpers are enumerated: CrossHair 0.0.107 cannot build a symbolic
+# proxy for a `pathlib.Path` parameter (it raises in intersect_signatures on
+# both 3.13 and 3.14), so `_format_manifest_path` is excluded here and covered
+# instead by the Hypothesis property test in tests/unit.
+crosshair: build $(UV) ## Model-check bump_output pure-helper contracts (issue #95)
+	$(UV) run crosshair check \
+	  lading.commands.bump_output._build_changes_description \
+	  lading.commands.bump_output._format_header
 
 help: ## Show available targets
 	@grep -E '^[a-zA-Z_-]+:.*?##' $(MAKEFILE_LIST) | \

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -192,6 +192,38 @@ Cargo dependency-section names (`dependencies`, `dev-dependencies`, and
 re-declaring the literals, so a change to the recognized section set is made in
 exactly one place.
 
+### Model checking the formatting helpers
+
+Three pure helpers in `lading/commands/bump_output.py` carry PEP 316
+docstring contracts (`pre:`/`post:` lines):
+
+- `_build_changes_description` — assembles the Oxford-comma-joined
+  category description from a `BumpChanges` instance.
+- `_format_header` — formats the top-level bump result header line.
+- `_format_manifest_path` — formats a single manifest path for display
+  in the bump output.
+
+Run CrossHair symbolic-execution model checking against the first two
+helpers with:
+
+```bash
+make crosshair
+```
+
+`crosshair-tool` is a dev dependency. `[tool.crosshair]` in
+`pyproject.toml` sets per-path and per-condition timeouts to keep the
+check bounded. `make crosshair` is **not** part of `make all` or CI; it
+is an on-demand check intended for targeted verification when the
+formatting helpers change.
+
+`_format_manifest_path` keeps its `pre:`/`post:` contract but is
+intentionally excluded from the `make crosshair` run. CrossHair 0.0.107
+cannot construct a symbolic `pathlib.Path` proxy — it raises in
+`intersect_signatures` on both CPython 3.13 and 3.14. Its behaviour is
+instead covered by the Hypothesis property test in
+`tests/unit/test_bump_command_internals.py`, which exercises
+`_format_result_message` across a wide range of path inputs.
+
 ## Workspace discovery helpers
 
 ### Workspace path normalization (`lading/utils/path.py`)

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -145,9 +145,12 @@ README adoption, and lockfile reporting. Keep user-facing summary construction
 in `lading.commands.bump_output` rather than formatting messages inline in the
 workflow.
 
-`lading.commands.bump_output` renders the CLI summary from a `BumpChanges`
-record. This record includes manifests, documentation files, transposed
-readmes, and lockfiles that changed during a bump run.
+`lading.commands.bump_output` is the sole owner of `BumpChanges` and all bump
+result-message formatting; `bump.py` imports these helpers and must not
+re-declare them. The `BumpChanges` record includes manifests, documentation
+files, transposed readmes, and lockfiles that changed during a bump run.
+Changed-category descriptions join with an Oxford comma for three or more
+categories (for example, "2 manifest(s), 1 readme file(s), and 1 lockfile(s)").
 
 `lading.commands.bump_readme` owns workspace README adoption during
 `lading bump`. The module copies the workspace `README.md` into each crate that

--- a/docs/users-guide.md
+++ b/docs/users-guide.md
@@ -90,6 +90,12 @@ adjacent `Cargo.toml`. Refreshed lockfiles are listed in the command output
 with a `(lockfile)` suffix. In dry-run mode the lockfiles are listed but not
 modified.
 
+Where a member crate sets `readme.workspace = true`, `lading bump` also adopts
+the workspace `README.md` into that crate's directory and rewrites relative
+Markdown links so they still resolve from the crate directory. Adopted README
+files are listed in the command output with a `(readme)` suffix. In dry-run
+mode the files are listed but not written.
+
 If `bump.documentation.globs` is configured, `lading` also searches those
 Markdown files for TOML code fences and updates version values that refer to
 workspace crates.

--- a/lading/commands/bump.py
+++ b/lading/commands/bump.py
@@ -10,6 +10,7 @@ import typing as typ
 
 from lading import config as config_module
 from lading.commands import bump_docs, bump_lockfiles, bump_readme, bump_toml
+from lading.commands.bump_output import BumpChanges, _format_result_message
 from lading.utils import normalise_workspace_root
 
 if typ.TYPE_CHECKING:
@@ -85,16 +86,6 @@ class BumpOptions:
 
 
 @dc.dataclass(frozen=True, slots=True)
-class BumpChanges:
-    """Collection of files altered by a bump run."""
-
-    manifests: cabc.Sequence[Path] = ()
-    documents: cabc.Sequence[Path] = ()
-    lockfiles: cabc.Sequence[Path] = ()
-    transposed_readmes: cabc.Sequence[Path] = ()
-
-
-@dc.dataclass(frozen=True, slots=True)
 class _BumpContext:
     """Initialisation context for bump operations."""
 
@@ -105,56 +96,6 @@ class _BumpContext:
     workspace_manifest: Path
     excluded: frozenset[str]
     updated_crate_names: frozenset[str]
-
-
-def _build_changes_description(changes: BumpChanges) -> str:
-    """Build a human-readable description of changed files."""
-    parts: list[str] = []
-    if changes.manifests:
-        parts.append(f"{len(changes.manifests)} manifest(s)")
-    if changes.documents:
-        parts.append(f"{len(changes.documents)} documentation file(s)")
-    if changes.transposed_readmes:
-        parts.append(f"{len(changes.transposed_readmes)} readme file(s)")
-    if changes.lockfiles:
-        parts.append(f"{len(changes.lockfiles)} lockfile(s)")
-    return parts[0] if len(parts) == 1 else " and ".join(parts)
-
-
-def _format_no_changes_message(target_version: str, *, dry_run: bool) -> str:
-    """Format message when no changes are required."""
-    if dry_run:
-        return (
-            "Dry run; no manifest changes required; "
-            f"all versions already {target_version}."
-        )
-    return f"No manifest changes required; all versions already {target_version}."
-
-
-def _format_header(description: str, target_version: str, *, dry_run: bool) -> str:
-    """Format the summary header line."""
-    if dry_run:
-        return f"Dry run; would update version to {target_version} in {description}:"
-    return f"Updated version to {target_version} in {description}:"
-
-
-def _format_manifest_path(manifest_path: Path, workspace_root: Path) -> str:
-    """Return ``manifest_path`` relative to ``workspace_root`` when possible."""
-    try:
-        relative = manifest_path.relative_to(workspace_root)
-    except ValueError:
-        return str(manifest_path)
-    return str(relative)
-
-
-def _has_changes(changes: BumpChanges) -> bool:
-    """Return True when a bump run changed at least one file category."""
-    return any((
-        changes.manifests,
-        changes.documents,
-        changes.transposed_readmes,
-        changes.lockfiles,
-    ))
 
 
 def run(
@@ -400,38 +341,6 @@ def _update_crate_manifest(
         target_version,
         crate_options,
     )
-
-
-def _format_result_message(
-    changes: BumpChanges,
-    target_version: str,
-    *,
-    dry_run: bool,
-    workspace_root: Path,
-) -> str:
-    """Summarise the bump outcome for CLI presentation."""
-    if not _has_changes(changes):
-        return _format_no_changes_message(target_version, dry_run=dry_run)
-
-    description = _build_changes_description(changes)
-    header = _format_header(description, target_version, dry_run=dry_run)
-    formatted_paths = [
-        f"- {_format_manifest_path(manifest_path, workspace_root)}"
-        for manifest_path in changes.manifests
-    ]
-    formatted_paths.extend(
-        f"- {_format_manifest_path(document_path, workspace_root)} (documentation)"
-        for document_path in changes.documents
-    )
-    formatted_paths.extend(
-        f"- {_format_manifest_path(readme_path, workspace_root)} (readme)"
-        for readme_path in changes.transposed_readmes
-    )
-    formatted_paths.extend(
-        f"- {_format_manifest_path(lockfile_path, workspace_root)} (lockfile)"
-        for lockfile_path in changes.lockfiles
-    )
-    return "\n".join([header, *formatted_paths])
 
 
 def _validate_bump_options(options: BumpOptions) -> tuple[LadingConfig, WorkspaceGraph]:

--- a/lading/commands/bump_output.py
+++ b/lading/commands/bump_output.py
@@ -9,8 +9,8 @@ general-purpose formatting API.
 Classes
 -------
 BumpChanges
-    Public value object describing updated manifests, documentation files, and
-    lockfiles.
+    Public value object describing updated manifests, documentation files,
+    transposed readmes, and lockfiles.
 
 Functions
 ---------
@@ -22,7 +22,11 @@ _format_result_message
 Notes
 -----
 Internal helpers ``_build_changes_description``, ``_format_no_changes_message``,
-``_format_header``, and ``_format_manifest_path`` are not part of the public API.
+``_format_header``, ``_format_manifest_path``, and ``_has_changes`` are not part
+of the public API.
+
+This module is the sole owner of ``BumpChanges`` and bump result-message
+formatting (issue #95); no other module may re-declare them.
 """
 
 from __future__ import annotations
@@ -54,11 +58,14 @@ class BumpChanges:
         Documentation files updated by TOML snippet rewriting.
     lockfiles : Sequence[Path]
         Cargo lockfiles regenerated after manifest updates.
+    transposed_readmes : Sequence[Path]
+        Crate README files adopted from the workspace README.
     """
 
     manifests: cabc.Sequence[Path] = ()
     documents: cabc.Sequence[Path] = ()
     lockfiles: cabc.Sequence[Path] = ()
+    transposed_readmes: cabc.Sequence[Path] = ()
 
 
 def _build_changes_description(changes: BumpChanges) -> str:
@@ -68,6 +75,8 @@ def _build_changes_description(changes: BumpChanges) -> str:
         parts.append(f"{len(changes.manifests)} manifest(s)")
     if changes.documents:
         parts.append(f"{len(changes.documents)} documentation file(s)")
+    if changes.transposed_readmes:
+        parts.append(f"{len(changes.transposed_readmes)} readme file(s)")
     if changes.lockfiles:
         parts.append(f"{len(changes.lockfiles)} lockfile(s)")
     if len(parts) == _SINGLE_CHANGE_CATEGORY_COUNT:
@@ -94,6 +103,16 @@ def _format_header(description: str, target_version: str, *, dry_run: bool) -> s
     return f"Updated version to {target_version} in {description}:"
 
 
+def _has_changes(changes: BumpChanges) -> bool:
+    """Return True when a bump run changed at least one file category."""
+    return any((
+        changes.manifests,
+        changes.documents,
+        changes.transposed_readmes,
+        changes.lockfiles,
+    ))
+
+
 def _format_result_message(
     changes: BumpChanges,
     target_version: str,
@@ -102,7 +121,7 @@ def _format_result_message(
     workspace_root: Path,
 ) -> str:
     """Summarise the bump outcome for CLI presentation."""
-    if not any((changes.manifests, changes.documents, changes.lockfiles)):
+    if not _has_changes(changes):
         return _format_no_changes_message(target_version, dry_run=dry_run)
 
     description = _build_changes_description(changes)
@@ -114,6 +133,10 @@ def _format_result_message(
     formatted_paths.extend(
         f"- {_format_manifest_path(document_path, workspace_root)} (documentation)"
         for document_path in changes.documents
+    )
+    formatted_paths.extend(
+        f"- {_format_manifest_path(readme_path, workspace_root)} (readme)"
+        for readme_path in changes.transposed_readmes
     )
     formatted_paths.extend(
         f"- {_format_manifest_path(lockfile_path, workspace_root)} (lockfile)"

--- a/lading/commands/bump_output.py
+++ b/lading/commands/bump_output.py
@@ -33,10 +33,12 @@ from __future__ import annotations
 
 import collections.abc as cabc
 import dataclasses as dc
-import typing as typ
 
-if typ.TYPE_CHECKING:
-    from pathlib import Path
+# ``Path`` is imported at runtime (not under ``TYPE_CHECKING``) so CrossHair can
+# resolve the annotations on the pure helpers when model-checking their
+# contracts (issue #95). ``ruff`` TC003 is intentionally ignored for this file's
+# stdlib type-only imports.
+from pathlib import Path
 
 _SINGLE_CHANGE_CATEGORY_COUNT = 1
 _PAIRED_CHANGE_CATEGORY_COUNT = 2
@@ -69,7 +71,14 @@ class BumpChanges:
 
 
 def _build_changes_description(changes: BumpChanges) -> str:
-    """Build a human-readable description of changed files."""
+    """Build a human-readable description of changed files.
+
+    CrossHair contracts (issue #95); model-check with ``make crosshair``.
+
+    pre: _has_changes(changes)
+    post: len(__return__) > 0
+    post: " and and " not in __return__
+    """
     parts: list[str] = []
     if changes.manifests:
         parts.append(f"{len(changes.manifests)} manifest(s)")
@@ -97,7 +106,14 @@ def _format_no_changes_message(target_version: str, *, dry_run: bool) -> str:
 
 
 def _format_header(description: str, target_version: str, *, dry_run: bool) -> str:
-    """Format the summary header line."""
+    """Format the summary header line.
+
+    CrossHair contracts (issue #95); model-check with ``make crosshair``.
+
+    post: __return__.endswith(":")
+    post: target_version in __return__
+    post: description in __return__
+    """
     if dry_run:
         return f"Dry run; would update version to {target_version} in {description}:"
     return f"Updated version to {target_version} in {description}:"
@@ -146,7 +162,12 @@ def _format_result_message(
 
 
 def _format_manifest_path(manifest_path: Path, workspace_root: Path) -> str:
-    """Return ``manifest_path`` relative to ``workspace_root`` when possible."""
+    """Return ``manifest_path`` relative to ``workspace_root`` when possible.
+
+    CrossHair contracts (issue #95); model-check with ``make crosshair``.
+
+    post: isinstance(__return__, str)
+    """
     try:
         relative = manifest_path.relative_to(workspace_root)
     except ValueError:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,6 +48,7 @@ dev = [
     # code is pathlib + cuprum only (docs/roadmap.md Phase 5).
     "plumbum>=1.8",
     "pyyaml>=6.0.3",
+    "crosshair-tool>=0.0.107",
 ]
 
 [tool.ruff]
@@ -365,6 +366,12 @@ enable = [
 [tool.pytest.ini_options]
 # Tests automatically killed after seconds elapsed
 timeout = 30
+
+[tool.crosshair]
+# Bound symbolic execution so `make crosshair` cannot run unbounded when
+# model-checking the bump_output pure-helper contracts (issue #95).
+per_path_timeout = 4
+per_condition_timeout = 30
 
 [tool.mutmut]
 source_paths = ["lading/"]

--- a/tests/unit/__snapshots__/test_bump_command_internals.ambr
+++ b/tests/unit/__snapshots__/test_bump_command_internals.ambr
@@ -1,7 +1,25 @@
 # serializer version: 1
+# name: test_format_result_message_four_categories_snapshot[dry_run]
+  list([
+    'Dry run; would update version to 2.0.0 in 1 manifest(s), 1 documentation file(s), 1 readme file(s), and 1 lockfile(s):',
+    '- Cargo.toml',
+    '- README.md (documentation)',
+    '- crates/alpha/README.md (readme)',
+    '- Cargo.lock (lockfile)',
+  ])
+# ---
+# name: test_format_result_message_four_categories_snapshot[live]
+  list([
+    'Updated version to 2.0.0 in 1 manifest(s), 1 documentation file(s), 1 readme file(s), and 1 lockfile(s):',
+    '- Cargo.toml',
+    '- README.md (documentation)',
+    '- crates/alpha/README.md (readme)',
+    '- Cargo.lock (lockfile)',
+  ])
+# ---
 # name: test_format_result_message_handles_changes[all_changes]
   list([
-    'Updated version to 7.8.9 in 2 manifest(s) and 1 documentation file(s) and 1 readme file(s):',
+    'Updated version to 7.8.9 in 2 manifest(s), 1 documentation file(s), and 1 readme file(s):',
     '- Cargo.toml',
     '- member/Cargo.toml',
     '- README.md (documentation)',

--- a/tests/unit/test_bump_command_internals.py
+++ b/tests/unit/test_bump_command_internals.py
@@ -558,38 +558,30 @@ def _expected_description(categories: list[str]) -> str:
     return f"{', '.join(categories[:-1])}, and {categories[-1]}"
 
 
-def _build_expected_body(
-    root: Path,
-    manifests: tuple[Path, ...],
-    documents: tuple[Path, ...],
-    readmes: tuple[Path, ...],
-    lockfiles: tuple[Path, ...],
-) -> list[str]:
+def _build_expected_body(root: Path, changes: bump_output.BumpChanges) -> list[str]:
     """Return the expected ``"- <rel_path>"`` body lines in render order."""
     return [
-        *(f"- {path.relative_to(root)}" for path in manifests),
-        *(f"- {path.relative_to(root)} (documentation)" for path in documents),
-        *(f"- {path.relative_to(root)} (readme)" for path in readmes),
-        *(f"- {path.relative_to(root)} (lockfile)" for path in lockfiles),
+        *(f"- {path.relative_to(root)}" for path in changes.manifests),
+        *(f"- {path.relative_to(root)} (documentation)" for path in changes.documents),
+        *(
+            f"- {path.relative_to(root)} (readme)"
+            for path in changes.transposed_readmes
+        ),
+        *(f"- {path.relative_to(root)} (lockfile)" for path in changes.lockfiles),
     ]
 
 
-def _build_expected_categories(
-    manifests: tuple[Path, ...],
-    documents: tuple[Path, ...],
-    readmes: tuple[Path, ...],
-    lockfiles: tuple[Path, ...],
-) -> list[str]:
+def _build_expected_categories(changes: bump_output.BumpChanges) -> list[str]:
     """Return ordered category descriptions for the present change sets."""
     categories: list[str] = []
-    if manifests:
-        categories.append(f"{len(manifests)} manifest(s)")
-    if documents:
-        categories.append(f"{len(documents)} documentation file(s)")
-    if readmes:
-        categories.append(f"{len(readmes)} readme file(s)")
-    if lockfiles:
-        categories.append(f"{len(lockfiles)} lockfile(s)")
+    if changes.manifests:
+        categories.append(f"{len(changes.manifests)} manifest(s)")
+    if changes.documents:
+        categories.append(f"{len(changes.documents)} documentation file(s)")
+    if changes.transposed_readmes:
+        categories.append(f"{len(changes.transposed_readmes)} readme file(s)")
+    if changes.lockfiles:
+        categories.append(f"{len(changes.lockfiles)} lockfile(s)")
     return categories
 
 
@@ -627,11 +619,9 @@ def test_result_message_grammar_and_path_rendering(
         return
 
     lines = message.splitlines()
-    assert lines[1:] == _build_expected_body(
-        root, manifests, documents, readmes, lockfiles
-    )
+    assert lines[1:] == _build_expected_body(root, changes)
 
-    categories = _build_expected_categories(manifests, documents, readmes, lockfiles)
+    categories = _build_expected_categories(changes)
     expected_header = (
         f"Updated version to 1.2.3 in {_expected_description(categories)}:"
     )

--- a/tests/unit/test_bump_command_internals.py
+++ b/tests/unit/test_bump_command_internals.py
@@ -622,7 +622,7 @@ def test_result_message_grammar_and_path_rendering(
         changes, "1.2.3", dry_run=False, workspace_root=root
     )
 
-    if not (manifests or documents or readmes or lockfiles):
+    if not bump_output._has_changes(changes):
         assert message == "No manifest changes required; all versions already 1.2.3."
         return
 

--- a/tests/unit/test_bump_command_internals.py
+++ b/tests/unit/test_bump_command_internals.py
@@ -614,7 +614,7 @@ def test_result_message_grammar_and_path_rendering(
         changes, "1.2.3", dry_run=False, workspace_root=root
     )
 
-    if not bump_output._has_changes(changes):
+    if not any((manifests, documents, readmes, lockfiles)):
         assert message == "No manifest changes required; all versions already 1.2.3."
         return
 
@@ -652,3 +652,17 @@ def test_format_result_message_four_categories_snapshot(
 
     assert snapshot(name="live") == live.splitlines()
     assert snapshot(name="dry_run") == dry.splitlines()
+
+
+def test_format_result_message_lockfile_only(tmp_path: Path) -> None:
+    """A lockfile-only BumpChanges renders correctly (not 'no changes')."""
+    root = tmp_path
+    lockfile = root / "Cargo.lock"
+    changes = bump_output.BumpChanges(lockfiles=(lockfile,))
+    message = bump_output._format_result_message(
+        changes, "1.2.3", dry_run=False, workspace_root=root
+    )
+    assert message != "No manifest changes required; all versions already 1.2.3."
+    lines = message.splitlines()
+    assert lines[0] == "Updated version to 1.2.3 in 1 lockfile(s):"
+    assert lines[1] == f"- {lockfile.relative_to(root)} (lockfile)"

--- a/tests/unit/test_bump_command_internals.py
+++ b/tests/unit/test_bump_command_internals.py
@@ -546,7 +546,7 @@ def test_update_dependency_sections_workspace_dev_and_build() -> None:
 # Canonical bump_output formatting (issue #95)
 # ---------------------------------------------------------------------------
 
-_category_count = st.integers(min_value=0, max_value=3)
+_CATEGORY_COUNT = st.integers(min_value=0, max_value=3)
 
 
 def _expected_description(categories: list[str]) -> str:
@@ -586,10 +586,10 @@ def _build_expected_categories(changes: bump_output.BumpChanges) -> list[str]:
 
 
 @given(
-    manifest_count=_category_count,
-    document_count=_category_count,
-    readme_count=_category_count,
-    lockfile_count=_category_count,
+    manifest_count=_CATEGORY_COUNT,
+    document_count=_CATEGORY_COUNT,
+    readme_count=_CATEGORY_COUNT,
+    lockfile_count=_CATEGORY_COUNT,
 )
 def test_result_message_grammar_and_path_rendering(
     manifest_count: int,

--- a/tests/unit/test_bump_command_internals.py
+++ b/tests/unit/test_bump_command_internals.py
@@ -4,8 +4,11 @@ from __future__ import annotations
 
 import dataclasses as dc
 import typing as typ
+from pathlib import Path
 
+import hypothesis.strategies as st
 import pytest
+from hypothesis import given
 from tomlkit import parse as parse_toml
 
 from lading.workspace import WorkspaceCrate, WorkspaceDependency, WorkspaceGraph
@@ -16,8 +19,6 @@ from tests.helpers.workspace_builders import (
 )
 
 if typ.TYPE_CHECKING:
-    from pathlib import Path
-
     from syrupy.assertion import SnapshotAssertion
 from lading.commands import bump, bump_output
 
@@ -188,8 +189,8 @@ def test_build_changes_description_counts_sections(tmp_path: Path) -> None:
         transposed_readmes=(tmp_path / "crates" / "alpha" / "README.md",),
     )
     assert (
-        bump._build_changes_description(changes)
-        == "2 manifest(s) and 1 documentation file(s) and 1 readme file(s)"
+        bump_output._build_changes_description(changes)
+        == "2 manifest(s), 1 documentation file(s), and 1 readme file(s)"
     )
 
     changes = bump.BumpChanges(
@@ -198,9 +199,8 @@ def test_build_changes_description_counts_sections(tmp_path: Path) -> None:
         transposed_readmes=(tmp_path / "crates" / "alpha" / "README.md",),
         lockfiles=(tmp_path / "Cargo.lock",),
     )
-    assert bump._build_changes_description(changes) == (
-        "1 manifest(s) and 1 documentation file(s) and "
-        "1 readme file(s) and 1 lockfile(s)"
+    assert bump_output._build_changes_description(changes) == (
+        "1 manifest(s), 1 documentation file(s), 1 readme file(s), and 1 lockfile(s)"
     )
 
 
@@ -540,3 +540,102 @@ def test_update_dependency_sections_workspace_dev_and_build() -> None:
     assert document["workspace"]["dev-dependencies"]["alpha"].value == "~3.0.0"
     build_deps = document["workspace"]["build-dependencies"]
     assert build_deps["beta"]["version"].value == "3.0.0"
+
+
+# ---------------------------------------------------------------------------
+# Canonical bump_output formatting (issue #95)
+# ---------------------------------------------------------------------------
+
+_category_count = st.integers(min_value=0, max_value=3)
+
+
+def _expected_description(categories: list[str]) -> str:
+    """Return the reference Oxford-comma joining for ``categories``."""
+    if len(categories) == 1:
+        return categories[0]
+    if len(categories) == 2:
+        return " and ".join(categories)
+    return f"{', '.join(categories[:-1])}, and {categories[-1]}"
+
+
+@given(
+    manifest_count=_category_count,
+    document_count=_category_count,
+    readme_count=_category_count,
+    lockfile_count=_category_count,
+)
+def test_result_message_grammar_and_path_rendering(
+    manifest_count: int,
+    document_count: int,
+    readme_count: int,
+    lockfile_count: int,
+) -> None:
+    """Any category combination renders correct grammar and unique paths."""
+    root = Path("/ws")
+    manifests = tuple(root / f"m{i}" / "Cargo.toml" for i in range(manifest_count))
+    documents = tuple(root / f"doc{i}.md" for i in range(document_count))
+    readmes = tuple(root / f"r{i}" / "README.md" for i in range(readme_count))
+    lockfiles = tuple(root / f"l{i}" / "Cargo.lock" for i in range(lockfile_count))
+    changes = bump_output.BumpChanges(
+        manifests=manifests,
+        documents=documents,
+        lockfiles=lockfiles,
+        transposed_readmes=readmes,
+    )
+
+    message = bump_output._format_result_message(
+        changes, "1.2.3", dry_run=False, workspace_root=root
+    )
+
+    if not (manifests or documents or readmes or lockfiles):
+        assert message == "No manifest changes required; all versions already 1.2.3."
+        return
+
+    lines = message.splitlines()
+    expected_body = [
+        *(f"- {path.relative_to(root)}" for path in manifests),
+        *(f"- {path.relative_to(root)} (documentation)" for path in documents),
+        *(f"- {path.relative_to(root)} (readme)" for path in readmes),
+        *(f"- {path.relative_to(root)} (lockfile)" for path in lockfiles),
+    ]
+    assert lines[1:] == expected_body
+
+    categories = []
+    if manifests:
+        categories.append(f"{len(manifests)} manifest(s)")
+    if documents:
+        categories.append(f"{len(documents)} documentation file(s)")
+    if readmes:
+        categories.append(f"{len(readmes)} readme file(s)")
+    if lockfiles:
+        categories.append(f"{len(lockfiles)} lockfile(s)")
+    expected_header = (
+        f"Updated version to 1.2.3 in {_expected_description(categories)}:"
+    )
+    assert lines[0] == expected_header
+    assert " and and " not in lines[0]
+    if len(categories) >= 3:
+        assert ", and " in lines[0]
+
+
+def test_format_result_message_four_categories_snapshot(
+    tmp_path: Path, snapshot: SnapshotAssertion
+) -> None:
+    """All four categories render with Oxford-comma grammar (dry-run and live)."""
+    root = tmp_path
+    changes = bump_output.BumpChanges(
+        manifests=(root / "Cargo.toml",),
+        documents=(root / "README.md",),
+        lockfiles=(root / "Cargo.lock",),
+        transposed_readmes=(root / "crates" / "alpha" / "README.md",),
+    )
+
+    live = bump_output._format_result_message(
+        changes, "2.0.0", dry_run=False, workspace_root=root
+    )
+    dry = bump_output._format_result_message(
+        changes, "2.0.0", dry_run=True, workspace_root=root
+    )
+
+    assert snapshot(name="live") == live.splitlines()
+    assert snapshot(name="dry_run") == dry.splitlines()

--- a/tests/unit/test_bump_command_internals.py
+++ b/tests/unit/test_bump_command_internals.py
@@ -558,6 +558,41 @@ def _expected_description(categories: list[str]) -> str:
     return f"{', '.join(categories[:-1])}, and {categories[-1]}"
 
 
+def _build_expected_body(
+    root: Path,
+    manifests: tuple[Path, ...],
+    documents: tuple[Path, ...],
+    readmes: tuple[Path, ...],
+    lockfiles: tuple[Path, ...],
+) -> list[str]:
+    """Return the expected ``"- <rel_path>"`` body lines in render order."""
+    return [
+        *(f"- {path.relative_to(root)}" for path in manifests),
+        *(f"- {path.relative_to(root)} (documentation)" for path in documents),
+        *(f"- {path.relative_to(root)} (readme)" for path in readmes),
+        *(f"- {path.relative_to(root)} (lockfile)" for path in lockfiles),
+    ]
+
+
+def _build_expected_categories(
+    manifests: tuple[Path, ...],
+    documents: tuple[Path, ...],
+    readmes: tuple[Path, ...],
+    lockfiles: tuple[Path, ...],
+) -> list[str]:
+    """Return ordered category descriptions for the present change sets."""
+    categories: list[str] = []
+    if manifests:
+        categories.append(f"{len(manifests)} manifest(s)")
+    if documents:
+        categories.append(f"{len(documents)} documentation file(s)")
+    if readmes:
+        categories.append(f"{len(readmes)} readme file(s)")
+    if lockfiles:
+        categories.append(f"{len(lockfiles)} lockfile(s)")
+    return categories
+
+
 @given(
     manifest_count=_category_count,
     document_count=_category_count,
@@ -592,23 +627,11 @@ def test_result_message_grammar_and_path_rendering(
         return
 
     lines = message.splitlines()
-    expected_body = [
-        *(f"- {path.relative_to(root)}" for path in manifests),
-        *(f"- {path.relative_to(root)} (documentation)" for path in documents),
-        *(f"- {path.relative_to(root)} (readme)" for path in readmes),
-        *(f"- {path.relative_to(root)} (lockfile)" for path in lockfiles),
-    ]
-    assert lines[1:] == expected_body
+    assert lines[1:] == _build_expected_body(
+        root, manifests, documents, readmes, lockfiles
+    )
 
-    categories = []
-    if manifests:
-        categories.append(f"{len(manifests)} manifest(s)")
-    if documents:
-        categories.append(f"{len(documents)} documentation file(s)")
-    if readmes:
-        categories.append(f"{len(readmes)} readme file(s)")
-    if lockfiles:
-        categories.append(f"{len(lockfiles)} lockfile(s)")
+    categories = _build_expected_categories(manifests, documents, readmes, lockfiles)
     expected_header = (
         f"Updated version to 1.2.3 in {_expected_description(categories)}:"
     )

--- a/uv.lock
+++ b/uv.lock
@@ -26,6 +26,19 @@ wheels = [
 ]
 
 [[package]]
+name = "cattrs"
+version = "25.2.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "attrs" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e3/42/988b3a667967e9d2d32346e7ed7edee540ef1cee829b53ef80aa8d4a0222/cattrs-25.2.0.tar.gz", hash = "sha256:f46c918e955db0177be6aa559068390f71988e877c603ae2e56c71827165cc06", size = 506531, upload-time = "2025-08-31T20:41:59.301Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/20/a5/b3771ac30b590026b9d721187110194ade05bfbea3d98b423a9cafd80959/cattrs-25.2.0-py3-none-any.whl", hash = "sha256:539d7eedee7d2f0706e4e109182ad096d608ba84633c32c75ef3458f1d11e8f1", size = 70040, upload-time = "2025-08-31T20:41:57.543Z" },
+]
+
+[[package]]
 name = "click"
 version = "8.3.3"
 source = { registry = "https://pypi.org/simple" }
@@ -113,6 +126,37 @@ wheels = [
 ]
 
 [[package]]
+name = "crosshair-tool"
+version = "0.0.107"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "importlib-metadata" },
+    { name = "packaging" },
+    { name = "pygls" },
+    { name = "typeshed-client" },
+    { name = "typing-extensions" },
+    { name = "typing-inspect" },
+    { name = "z3-solver" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/25/56/256d8880e713dbcb54878d671fd33be53d462d87694032513ed8d8b13334/crosshair_tool-0.0.107.tar.gz", hash = "sha256:43183729d8cce06bc4977945e1f0a38ac5852b2c3b0bd5b9d68cc88e981d8c82", size = 497134, upload-time = "2026-06-16T01:31:24.362Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/50/b9/4309d529c79562abbde6b3b226c3fc2fc1861477a1751e0270bf4647a851/crosshair_tool-0.0.107-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:04b11d347d045510272bf9bdc9bf8acdb0ca6dab22626ece848fa23da0c7a566", size = 587883, upload-time = "2026-06-16T01:30:50.562Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/17/8477740c5e79b53020c537e0a11c69e9aa06791916eb1c3862205dbb343a/crosshair_tool-0.0.107-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:d3706b7a0e5b3c5a80d7c33433731b0d399c0cbce4ea327ba3ab37c7ab1746b4", size = 571865, upload-time = "2026-06-16T01:30:51.801Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/12/e1e48988d00b09f1364611aed3a8ff16d6e6694404fd84c8e02cc41e6b69/crosshair_tool-0.0.107-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:d9e3b332ee7ee2b08a1b248ca08a1948c33d3e18cb2a69a7524675b5d5d2d3ee", size = 572523, upload-time = "2026-06-16T01:30:52.886Z" },
+    { url = "https://files.pythonhosted.org/packages/12/2c/812bbaa1486f29da5b5258b7836249cc375f971e4cb1a18ddca8264aeea2/crosshair_tool-0.0.107-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:1e1753d184a76a4142e696c41b953947c61d47a80b830d4afef2318bee834166", size = 612718, upload-time = "2026-06-16T01:30:54.084Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/d1/19bea69b8bc14505f47cca30b6810adcf752e1330f0186c8271a6d2203be/crosshair_tool-0.0.107-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:9fd813914d8d339724ddc77c07f35ad95949ceba419a919359042ccac4ffb6a9", size = 611612, upload-time = "2026-06-16T01:30:55.443Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/58/ed6736b363ce13fbbb06f6ba9fa54d9d38f2138ad4c06bec54160c0532a4/crosshair_tool-0.0.107-cp313-cp313-win32.whl", hash = "sha256:df257f326db2750d1801a9e2bb6b6b49a11e23a87ea658486d68f057dc75b83c", size = 569589, upload-time = "2026-06-16T01:30:56.49Z" },
+    { url = "https://files.pythonhosted.org/packages/28/53/498177fe64a26d3885ce4aebe0cd6fc4e485c6c910f24b3cb0d6fbf0cef5/crosshair_tool-0.0.107-cp313-cp313-win_amd64.whl", hash = "sha256:18eacd757460d6990db61885d2e9d1f48f469938f73a780d4184796dd1134393", size = 570923, upload-time = "2026-06-16T01:30:57.779Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/23/afac70ffa51f25bcd5bb494cbba6f8a2245f982a2bfe4c1dca1b5ddf5ce4/crosshair_tool-0.0.107-cp314-cp314-macosx_10_13_universal2.whl", hash = "sha256:bf7e7c03887b1695cd37b9fdf13eec5a7b6280ae6c6dd60483f78f2f330cfef0", size = 585446, upload-time = "2026-06-16T01:30:58.908Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/f1/7fd0c3aa3dc24d6f6d83d1a1b0d3f9b6c4330c9724fe5206fe46d3504dcc/crosshair_tool-0.0.107-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:27013ea782da36aac5aeca17805a6b9bef6137629c1bc35d073e000d74312204", size = 570641, upload-time = "2026-06-16T01:31:00.178Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/17/17e480dc523865ef2ddba54d2576205b67da5e40d9df53c94c0e688b1233/crosshair_tool-0.0.107-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:fc89884352e9771a5b900dac1df496284fcd7b3b28d50dd01cda349a162ceeb5", size = 571312, upload-time = "2026-06-16T01:31:01.286Z" },
+    { url = "https://files.pythonhosted.org/packages/72/fc/bfeb764d27ee66e1b3a1e34626c240ed615aaf6b2cd2ed8a2e306e88020b/crosshair_tool-0.0.107-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:5fdfc5ee325dff47102e2160d986f16afa910811455226ca204bd1408baf8129", size = 650291, upload-time = "2026-06-16T01:31:02.643Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/e3/21a736cb7d055e3fb132400e3232644082b9149e2938da0bcbc5fb4e4a74/crosshair_tool-0.0.107-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:04ac1aa6622b8cbf18b2ef5d512d25ff7584302fdad893e8ce562ecf3a836357", size = 647904, upload-time = "2026-06-16T01:31:03.799Z" },
+    { url = "https://files.pythonhosted.org/packages/19/c3/e5bf6d917e66c114e0e02015e3fac8891d2548ec8be87e0bee54e500aecb/crosshair_tool-0.0.107-cp314-cp314-win32.whl", hash = "sha256:ec098254b1de5347028f985fd426ca604206844d783a2582858c5843ea461ab5", size = 568484, upload-time = "2026-06-16T01:31:04.913Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/c4/8e744bc676cf009fe88e579c68a372d2118c272e067eb0ad7d88d7f7e135/crosshair_tool-0.0.107-cp314-cp314-win_amd64.whl", hash = "sha256:43d0dddc25affb83cb5fb4fcfd2aaaca2954c9088edc86e78545e592ca75b773", size = 569657, upload-time = "2026-06-16T01:31:05.977Z" },
+]
+
+[[package]]
 name = "cuprum"
 version = "0.1.0"
 source = { registry = "https://pypi.org/simple" }
@@ -176,6 +220,27 @@ wheels = [
 ]
 
 [[package]]
+name = "importlib-metadata"
+version = "9.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "zipp" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a9/01/15bb152d77b21318514a96f43af312635eb2500c96b55398d020c93d86ea/importlib_metadata-9.0.0.tar.gz", hash = "sha256:a4f57ab599e6a2e3016d7595cfd72eb4661a5106e787a95bcc90c7105b831efc", size = 56405, upload-time = "2026-03-20T06:42:56.999Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/38/3d/2d244233ac4f76e38533cfcb2991c9eb4c7bf688ae0a036d30725b8faafe/importlib_metadata-9.0.0-py3-none-any.whl", hash = "sha256:2d21d1cc5a017bd0559e36150c21c830ab1dc304dedd1b7ea85d20f45ef3edd7", size = 27789, upload-time = "2026-03-20T06:42:55.665Z" },
+]
+
+[[package]]
+name = "importlib-resources"
+version = "7.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e4/06/b56dfa750b44e86157093bc8fca0ab81dccbf5260510de4eaf1cb69b5b99/importlib_resources-7.1.0.tar.gz", hash = "sha256:0722d4c6212489c530f2a145a34c0a7a3b4721bc96a15fada5930e2a0b760708", size = 44985, upload-time = "2026-04-12T16:36:09.232Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8a/db/55a262f3606bebcae07cc14095338471ad7c0bbcaa37707e6f0ee49725b7/importlib_resources-7.1.0-py3-none-any.whl", hash = "sha256:1bd7b48b4088eddb2cd16382150bb515af0bd2c70128194392725f82ad2c96a1", size = 37232, upload-time = "2026-04-12T16:36:08.219Z" },
+]
+
+[[package]]
 name = "iniconfig"
 version = "2.1.0"
 source = { registry = "https://pypi.org/simple" }
@@ -216,6 +281,7 @@ dependencies = [
 dev = [
     { name = "build" },
     { name = "cmd-mox" },
+    { name = "crosshair-tool" },
     { name = "hypothesis" },
     { name = "interrogate" },
     { name = "plumbum" },
@@ -242,6 +308,7 @@ requires-dist = [
 dev = [
     { name = "build" },
     { name = "cmd-mox", git = "https://github.com/leynos/cmd-mox?rev=f583c279a15760aba5cfd9bddf1fbbe9b1f8c429" },
+    { name = "crosshair-tool", specifier = ">=0.0.107" },
     { name = "hypothesis", specifier = ">=6" },
     { name = "interrogate", specifier = ">=1.7.0" },
     { name = "plumbum", specifier = ">=1.8" },
@@ -253,6 +320,19 @@ dev = [
     { name = "pyyaml", specifier = ">=6.0.3" },
     { name = "ruff", specifier = "==0.15.20" },
     { name = "syrupy", specifier = ">=5.1.0" },
+]
+
+[[package]]
+name = "lsprotocol"
+version = "2025.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "attrs" },
+    { name = "cattrs" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e9/26/67b84e6ec1402f0e6764ef3d2a0aaf9a79522cc1d37738f4e5bb0b21521a/lsprotocol-2025.0.0.tar.gz", hash = "sha256:e879da2b9301e82cfc3e60d805630487ac2f7ab17492f4f5ba5aaba94fe56c29", size = 74896, upload-time = "2025-06-17T21:30:18.156Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7b/f0/92f2d609d6642b5f30cb50a885d2bf1483301c69d5786286500d15651ef2/lsprotocol-2025.0.0-py3-none-any.whl", hash = "sha256:f9d78f25221f2a60eaa4a96d3b4ffae011b107537facee61d3da3313880995c7", size = 76250, upload-time = "2025-06-17T21:30:19.455Z" },
 ]
 
 [[package]]
@@ -373,6 +453,15 @@ wheels = [
 ]
 
 [[package]]
+name = "mypy-extensions"
+version = "1.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a2/6e/371856a3fb9d31ca8dac321cda606860fa4548858c0cc45d9d1d4ca2628b/mypy_extensions-1.1.0.tar.gz", hash = "sha256:52e68efc3284861e772bbcd66823fde5ae21fd2fdb51c62a211403730b916558", size = 6343, upload-time = "2025-04-22T14:54:24.164Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/79/7b/2c79738432f5c924bef5071f933bcc9efd0473bac3b4aa584a6f7c1c8df8/mypy_extensions-1.1.0-py3-none-any.whl", hash = "sha256:1be4cccdb0f2482337c4743e60421de3a356cd97508abadd57d47403e94f5505", size = 4963, upload-time = "2025-04-22T14:54:22.983Z" },
+]
+
+[[package]]
 name = "nodeenv"
 version = "1.9.1"
 source = { registry = "https://pypi.org/simple" }
@@ -437,6 +526,20 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/98/ff/fec109ceb715d2a6b4c4a85a61af3b40c723a961e8828319fbcb15b868dc/py-1.11.0.tar.gz", hash = "sha256:51c75c4126074b472f746a24399ad32f6053d1b34b68d2fa41e558e6f4a98719", size = 207796, upload-time = "2021-11-04T17:17:01.377Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f6/f0/10642828a8dfb741e5f3fbaac830550a518a775c7fff6f04a007259b0548/py-1.11.0-py2.py3-none-any.whl", hash = "sha256:607c53218732647dff4acdfcd50cb62615cedf612e72d1724fb1a0cc6405b378", size = 98708, upload-time = "2021-11-04T17:17:00.152Z" },
+]
+
+[[package]]
+name = "pygls"
+version = "2.1.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "attrs" },
+    { name = "cattrs" },
+    { name = "lsprotocol" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/da/2e/7bbe061d175c0baddde8fc9edb908a4c31ba5d9165b8c68e3439c3a9f138/pygls-2.1.1.tar.gz", hash = "sha256:1da03ba9053201bb337dcdd8d121df70feb2a91e1a0dcc74de5da79755b1a201", size = 55091, upload-time = "2026-03-25T11:19:10.541Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fd/1a/208293b6c350f5abea6941d5606080d4a492644052504f5312e5de30a902/pygls-2.1.1-py3-none-any.whl", hash = "sha256:510a6dea2476177230c7d851125e5948efdf3fdb9ebfd8543fc434972f8faed4", size = 68975, upload-time = "2026-03-25T11:19:11.374Z" },
 ]
 
 [[package]]
@@ -666,10 +769,60 @@ wheels = [
 ]
 
 [[package]]
+name = "typeshed-client"
+version = "2.12.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "importlib-resources" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/54/5d/97d6fa8c204b0d42be931e7a568b306cda43f93ff45f8b47537ee61390de/typeshed_client-2.12.0.tar.gz", hash = "sha256:54dcfa25fcff82cedcb1b51c03c1b3c51a614097aab8fe49e4316aff6f79d9c7", size = 529457, upload-time = "2026-06-02T04:00:51.51Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/85/98/3aef1587ec9b3a5cd062b8d8910545a0ee3715c31fd65b1f2386b27b94af/typeshed_client-2.12.0-py3-none-any.whl", hash = "sha256:da3ef54a0e60c0f45f59006b73a3cb20b1acbf7a784e982476d8193e8828ddf5", size = 796929, upload-time = "2026-06-02T04:00:49.643Z" },
+]
+
+[[package]]
 name = "typing-extensions"
 version = "4.15.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/72/94/1a15dd82efb362ac84269196e94cf00f187f7ed21c242792a923cdb1c61f/typing_extensions-4.15.0.tar.gz", hash = "sha256:0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466", size = 109391, upload-time = "2025-08-25T13:49:26.313Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/18/67/36e9267722cc04a6b9f15c7f3441c2363321a3ea07da7ae0c0707beb2a9c/typing_extensions-4.15.0-py3-none-any.whl", hash = "sha256:f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548", size = 44614, upload-time = "2025-08-25T13:49:24.86Z" },
+]
+
+[[package]]
+name = "typing-inspect"
+version = "0.9.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "mypy-extensions" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/dc/74/1789779d91f1961fa9438e9a8710cdae6bd138c80d7303996933d117264a/typing_inspect-0.9.0.tar.gz", hash = "sha256:b23fc42ff6f6ef6954e4852c1fb512cdd18dbea03134f91f856a95ccc9461f78", size = 13825, upload-time = "2023-05-24T20:25:47.612Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/65/f3/107a22063bf27bdccf2024833d3445f4eea42b2e598abfbd46f6a63b6cb0/typing_inspect-0.9.0-py3-none-any.whl", hash = "sha256:9ee6fc59062311ef8547596ab6b955e1b8aa46242d854bfc78f4f6b0eff35f9f", size = 8827, upload-time = "2023-05-24T20:25:45.287Z" },
+]
+
+[[package]]
+name = "z3-solver"
+version = "4.16.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/93/3b/2b714c40ef2ecf6d8aa080056b9c24a77fe4ca2c83abd83e9c93d34212ac/z3_solver-4.16.0.0.tar.gz", hash = "sha256:263d9ad668966e832c2b246ba0389298a599637793da2dc01cc5e4ef4b0b6c78", size = 5098891, upload-time = "2026-02-19T04:14:08.818Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2d/5d/9b277a80333db6b85fedd0f5082e311efcbaec47f2c44c57d38953c2d4d9/z3_solver-4.16.0.0-py3-none-macosx_15_0_arm64.whl", hash = "sha256:cc52843cfdd3d3f2cd24bedc62e71c18af8c8b7b23fb05e639ab60b01b5f8f2f", size = 36963251, upload-time = "2026-02-19T04:13:44.303Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/c4/fc99aa544930fb7bfcd88947c2788f318acaf1b9704a7a914445e204436a/z3_solver-4.16.0.0-py3-none-macosx_15_0_x86_64.whl", hash = "sha256:e292df40951523e4ecfbc8dee549d93dee00a3fe4ee4833270d19876b713e210", size = 47523873, upload-time = "2026-02-19T04:13:48.154Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/e6/98741b086b6e01630a55db1fbda596949f738204aac14ef35e64a9526ccb/z3_solver-4.16.0.0-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:afae2551f795670f0522cfce82132d129c408a2694adff71eb01ba0f2ece44f9", size = 31741807, upload-time = "2026-02-19T04:13:52.283Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/2e/295d467c7c796c01337bff790dbedc28cf279f9d365ed64aa9f8ca6b2ba1/z3_solver-4.16.0.0-py3-none-manylinux_2_38_aarch64.whl", hash = "sha256:358648c3b5ef82b9ec9a25711cf4fc498c7881f03a9f4a2ea6ffa9304ca65d94", size = 27326531, upload-time = "2026-02-19T04:13:55.787Z" },
+    { url = "https://files.pythonhosted.org/packages/34/df/29816ce4de24cca3acb007412f9c6fba603e55fcc27ce8c2aade0939057a/z3_solver-4.16.0.0-py3-none-win32.whl", hash = "sha256:cc64c4d41fbebe419fccddb044979c3d95b41214547db65eecdaa67fafef7fe0", size = 13341643, upload-time = "2026-02-19T04:13:58.88Z" },
+    { url = "https://files.pythonhosted.org/packages/86/20/cef4f4d70845df24572d005d19995f92b7f527eb2ffb63a3f5f938a0de2e/z3_solver-4.16.0.0-py3-none-win_amd64.whl", hash = "sha256:eb5df383cb6a3d6b7767dbdca348ac71f6f41e82f76c9ac42002a1f55e35f462", size = 16419861, upload-time = "2026-02-19T04:14:03.232Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/18/7dc1051093abfd6db56ce9addb63c624bfa31946ccb9cfc9be5e75237a26/z3_solver-4.16.0.0-py3-none-win_arm64.whl", hash = "sha256:28729eae2c89112e37697acce4d4517f5e44c6c54d36fed9cf914b06f380cbd6", size = 15084866, upload-time = "2026-02-19T04:14:06.355Z" },
+]
+
+[[package]]
+name = "zipp"
+version = "4.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b9/d8/eab98a517c14134c0b2eb4e2387bc5f457334293ec5d2dd3857ec2966802/zipp-4.1.0.tar.gz", hash = "sha256:4cb57381f544315db7688e976e922a2b18cdb513d21cc194eb42232ba2a3e602", size = 26214, upload-time = "2026-05-18T20:08:57.967Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3a/13/547360d81e6d88d58492968ffda9f9542854f11310ee556fef14260cc886/zipp-4.1.0-py3-none-any.whl", hash = "sha256:25ad4e16390cd314347dd8f1de67a2ac538ae658ed4ab9db16029c07c188e97f", size = 10238, upload-time = "2026-05-18T20:08:57.045Z" },
 ]


### PR DESCRIPTION
## Summary

Closes #95

- `bump_output.BumpChanges` gains `transposed_readmes`; the renderer emits the `(readme)` suffix and `_has_changes` is ported.
- `bump.py` deletes every inline formatting definition and imports `BumpChanges` / `_format_result_message` from `bump_output` — no formatting or `BumpChanges` declarations remain in `bump.py`.
- Fixes the latent grammar bug: descriptions now use the Oxford-comma form for 3+ categories ("A, B, and C") instead of "A and B and C and D".
- `docs/developers-guide.md` names `bump_output` as the sole owner.

### Review-feedback follow-ups

- Renames the property-test strategy constant `_category_count` → `_CATEGORY_COUNT` to match the UPPER_SNAKE_CASE convention for module-level constants.
- Adds the CrossHair model-checking mandated by the issue (see Testing).

## Testing

- Hypothesis property test over arbitrary category combinations (0–4 present, varying counts): grammar well-formedness and exactly-once path rendering with correct suffixes.
- New snapshots for the four-category message in dry-run and apply modes; the `all_changes` snapshot update shows precisely the Oxford-comma fix.
- CrossHair model checking (issue #95): the three pure helpers now carry PEP 316 `pre:`/`post:` contracts. `crosshair-tool` is a dev dependency, `[tool.crosshair]` bounds the search, and `make crosshair` model-checks `_build_changes_description` and `_format_header` (both clean, exit 0). `_format_manifest_path` keeps its contract but is excluded from the automated run because CrossHair 0.0.107 cannot build a symbolic `pathlib.Path` proxy (it raises in `intersect_signatures` on both CPython 3.13 and 3.14); its behaviour is covered by the Hypothesis property test that drives `_format_result_message` over many path inputs.
- `make check-fmt`, `make lint`, `make typecheck`, `make test` (684 tests; one publish BDD case hit the known shared-venv race — `ModuleNotFoundError: msgspec` in a spawned subprocess — and passes on an isolated warm-venv re-run), `make markdownlint`, and `make crosshair` all green.

## References

- Lody session: https://lody.ai/leynos/sessions/036353c3-f7cc-4ae2-bc88-1b316a83d042

🤖 Generated with [Claude Code](https://claude.com/claude-code)
