### PR TITLE
Add Hypothesis coverage for lockfile discovery invariants (#80)

### DIFF
--- a/tests/unit/test_lockfile.py
+++ b/tests/unit/test_lockfile.py
@@ -296,6 +296,18 @@ def test_returned_paths_are_subset_of_git_stdout(stdout: str) -> None:
             f"does not appear in git stdout lines: {tracked_lines!r}"
         )
 
+
+# ---------------------------------------------------------------------------
+# End-to-end discovery invariants (issue #80)
+# ---------------------------------------------------------------------------
+
+_tree_entry = st.tuples(
+    st.lists(_path_component, min_size=1, max_size=3),  # directory components
+    st.booleans(),  # has adjacent Cargo.toml
+    st.booleans(),  # appears in git ls-files output
+)
+
+
 def _stub_git_runner(stdout: str) -> cabc.Callable[..., tuple[int, str, str]]:
     """Return a runner producing ``stdout`` for git ls-files."""
 
@@ -310,6 +322,7 @@ def _stub_git_runner(stdout: str) -> cabc.Callable[..., tuple[int, str, str]]:
         return 0, stdout, ""
 
     return runner
+
 
 @given(entries=st.lists(_tree_entry, max_size=8))
 @settings(max_examples=40, deadline=None)

--- a/tests/unit/test_lockfile.py
+++ b/tests/unit/test_lockfile.py
@@ -4,11 +4,12 @@ from __future__ import annotations
 
 import collections.abc as cabc
 import string
+import tempfile
 from pathlib import Path
 
 import hypothesis.strategies as st
 import pytest
-from hypothesis import given
+from hypothesis import given, settings
 
 from lading.commands import lockfile
 from lading.utils import metrics
@@ -294,6 +295,70 @@ def test_returned_paths_are_subset_of_git_stdout(stdout: str) -> None:
             f"Returned path {path} (relative: {relative!r}) "
             f"does not appear in git stdout lines: {tracked_lines!r}"
         )
+
+def _stub_git_runner(stdout: str) -> cabc.Callable[..., tuple[int, str, str]]:
+    """Return a runner producing ``stdout`` for git ls-files."""
+
+    def runner(
+        command: cabc.Sequence[str],
+        *,
+        cwd: Path | None = None,
+        env: cabc.Mapping[str, str] | None = None,
+    ) -> tuple[int, str, str]:
+        del cwd, env
+        assert command[:2] == ("git", "ls-files")
+        return 0, stdout, ""
+
+    return runner
+
+@given(entries=st.lists(_tree_entry, max_size=8))
+@settings(max_examples=40, deadline=None)
+def test_discover_tracked_lockfiles_invariants(
+    entries: list[tuple[list[str], bool, bool]],
+) -> None:
+    """Discovery output satisfies all four filtering invariants.
+
+    For generated workspace trees (random ``Cargo.lock``/``Cargo.toml``
+    placements, ``target/`` subtrees at varying depths) and synthesised
+    ``git ls-files`` output, every returned path: ends with ``Cargo.lock``,
+    has no ``target`` component, has an adjacent ``Cargo.toml`` on disk, and
+    was present in the git output. The result is also complete: every
+    tracked lockfile satisfying the invariants is returned.
+    """
+    with tempfile.TemporaryDirectory(prefix="lading-hypothesis-") as tmp:
+        workspace_root = Path(tmp)
+        seen_dirs: dict[tuple[str, ...], tuple[bool, bool]] = {}
+        for components, has_toml, tracked in entries:
+            seen_dirs.setdefault(tuple(components), (has_toml, tracked))
+
+        tracked_lines: list[str] = []
+        for components, (has_toml, tracked) in seen_dirs.items():
+            directory = workspace_root.joinpath(*components)
+            directory.mkdir(parents=True, exist_ok=True)
+            (directory / "Cargo.lock").write_text("", encoding="utf-8")
+            if has_toml:
+                (directory / "Cargo.toml").write_text("", encoding="utf-8")
+            if tracked:
+                tracked_lines.append("/".join((*components, "Cargo.lock")))
+
+        stdout = "\n".join(tracked_lines)
+        result = lockfile.discover_tracked_lockfiles(
+            workspace_root, _stub_git_runner(stdout)
+        )
+
+        for path in result:
+            relative = path.relative_to(workspace_root)
+            assert path.name == "Cargo.lock"
+            assert "target" not in relative.parts
+            assert (path.parent / "Cargo.toml").exists()
+            assert str(relative) in tracked_lines
+
+        expected = {
+            workspace_root.joinpath(*components, "Cargo.lock")
+            for components, (has_toml, tracked) in seen_dirs.items()
+            if tracked and has_toml and "target" not in components
+        }
+        assert set(result) == expected
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_lockfile.py
+++ b/tests/unit/test_lockfile.py
@@ -324,6 +324,59 @@ def _stub_git_runner(stdout: str) -> cabc.Callable[..., tuple[int, str, str]]:
     return runner
 
 
+def _deduplicate_entries(
+    entries: list[tuple[list[str], bool, bool]],
+) -> dict[tuple[str, ...], tuple[bool, bool]]:
+    """Collapse duplicate directory entries, keeping the first occurrence."""
+    seen: dict[tuple[str, ...], tuple[bool, bool]] = {}
+    for components, has_toml, tracked in entries:
+        seen.setdefault(tuple(components), (has_toml, tracked))
+    return seen
+
+
+def _populate_workspace(
+    workspace_root: Path,
+    seen_dirs: dict[tuple[str, ...], tuple[bool, bool]],
+) -> list[str]:
+    """Materialise the workspace tree and return the tracked ls-files lines."""
+    tracked_lines: list[str] = []
+    for components, (has_toml, tracked) in seen_dirs.items():
+        directory = workspace_root.joinpath(*components)
+        directory.mkdir(parents=True, exist_ok=True)
+        (directory / "Cargo.lock").write_text("", encoding="utf-8")
+        if has_toml:
+            (directory / "Cargo.toml").write_text("", encoding="utf-8")
+        if tracked:
+            tracked_lines.append("/".join((*components, "Cargo.lock")))
+    return tracked_lines
+
+
+def _assert_output_invariants(
+    result: cabc.Sequence[Path],
+    workspace_root: Path,
+    tracked_lines: list[str],
+) -> None:
+    """Assert every returned path satisfies the four filtering invariants."""
+    for path in result:
+        relative = path.relative_to(workspace_root)
+        assert path.name == "Cargo.lock"
+        assert "target" not in relative.parts
+        assert (path.parent / "Cargo.toml").exists()
+        assert str(relative) in tracked_lines
+
+
+def _expected_lockfiles(
+    workspace_root: Path,
+    seen_dirs: dict[tuple[str, ...], tuple[bool, bool]],
+) -> set[Path]:
+    """Return the lockfiles discovery must yield for the generated tree."""
+    return {
+        workspace_root.joinpath(*components, "Cargo.lock")
+        for components, (has_toml, tracked) in seen_dirs.items()
+        if tracked and has_toml and "target" not in components
+    }
+
+
 @given(entries=st.lists(_tree_entry, max_size=8))
 @settings(max_examples=40, deadline=None)
 def test_discover_tracked_lockfiles_invariants(
@@ -340,38 +393,13 @@ def test_discover_tracked_lockfiles_invariants(
     """
     with tempfile.TemporaryDirectory(prefix="lading-hypothesis-") as tmp:
         workspace_root = Path(tmp)
-        seen_dirs: dict[tuple[str, ...], tuple[bool, bool]] = {}
-        for components, has_toml, tracked in entries:
-            seen_dirs.setdefault(tuple(components), (has_toml, tracked))
-
-        tracked_lines: list[str] = []
-        for components, (has_toml, tracked) in seen_dirs.items():
-            directory = workspace_root.joinpath(*components)
-            directory.mkdir(parents=True, exist_ok=True)
-            (directory / "Cargo.lock").write_text("", encoding="utf-8")
-            if has_toml:
-                (directory / "Cargo.toml").write_text("", encoding="utf-8")
-            if tracked:
-                tracked_lines.append("/".join((*components, "Cargo.lock")))
-
-        stdout = "\n".join(tracked_lines)
+        seen_dirs = _deduplicate_entries(entries)
+        tracked_lines = _populate_workspace(workspace_root, seen_dirs)
         result = lockfile.discover_tracked_lockfiles(
-            workspace_root, _stub_git_runner(stdout)
+            workspace_root, _stub_git_runner("\n".join(tracked_lines))
         )
-
-        for path in result:
-            relative = path.relative_to(workspace_root)
-            assert path.name == "Cargo.lock"
-            assert "target" not in relative.parts
-            assert (path.parent / "Cargo.toml").exists()
-            assert str(relative) in tracked_lines
-
-        expected = {
-            workspace_root.joinpath(*components, "Cargo.lock")
-            for components, (has_toml, tracked) in seen_dirs.items()
-            if tracked and has_toml and "target" not in components
-        }
-        assert set(result) == expected
+        _assert_output_invariants(result, workspace_root, tracked_lines)
+        assert set(result) == _expected_lockfiles(workspace_root, seen_dirs)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Closes #80

The filtering invariants of `discover_tracked_lockfiles` (exclude `target/` paths, require an adjacent `Cargo.toml`, restrict to git-tracked files) were verified only by fixed-scenario unit tests plus property tests of the internal `_lockfiles_with_manifests` helper.

Adds an end-to-end `@given` test that generates workspace trees with random `Cargo.lock`/`Cargo.toml` placements at varying nesting depths, `target/` subtrees at varying depths, and synthesised `git ls-files` output with varying tracked/untracked combinations. For every returned path it asserts the four invariants from the issue:

1. Path ends with `Cargo.lock`
2. No `target` component in the relative path
3. An adjacent `Cargo.toml` exists on disk
4. The path was present in the git ls-files output

plus completeness: every tracked lockfile satisfying the invariants is returned.

## Testing

- `make check-fmt`, `make lint`, `make typecheck`, and `make test` (562 passed) all green after rebasing onto current `main`.
- `coderabbit review --agent`: 0 findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Tests:
- Add a Hypothesis-based end-to-end test that generates random workspace trees and asserts discover_tracked_lockfiles respects filtering and completeness invariants.

## References

- Lody session: https://lody.ai/leynos/sessions/42a515fd-a1d7-4703-b025-90bc09883928
