### PR TITLE
Add Hypothesis tests for bump_lockfiles path resolution (#93)

### DIFF
--- a/tests/unit/test_bump_lockfiles.py
+++ b/tests/unit/test_bump_lockfiles.py
@@ -286,13 +286,37 @@ _SEGMENT = st.text(
     max_size=10,
 )
 
+
+@st.composite
+def _inside_dir(draw: st.DrawFn) -> list[str]:
+    """Draw a relative directory path that stays within the workspace.
+
+    Alongside real segments and redundant ``.`` segments, this emits safe
+    ``..`` parent-traversal segments that never ascend above the workspace
+    root after normalisation: a ``..`` is only produced while a prior real
+    segment remains to cancel it (the running segment balance never drops
+    below zero). Cases such as ``crate/../Cargo.toml`` are therefore
+    exercised without allowing traversal above the root.
+    """
+    length = draw(st.integers(min_value=0, max_value=4))
+    components: list[str] = []
+    depth = 0
+    for _ in range(length):
+        options = [_SEGMENT, st.just(".")]
+        if depth > 0:
+            options.append(st.just(".."))
+        segment = draw(st.one_of(*options))
+        if segment == "..":
+            depth -= 1
+        elif segment != ".":
+            depth += 1
+        components.append(segment)
+    return components
+
+
 # Relative directory paths that stay inside the workspace, optionally with
-# redundant "." segments which normalise away.
-_INSIDE_DIR = st.lists(
-    st.one_of(_SEGMENT, st.just(".")),
-    min_size=0,
-    max_size=4,
-)
+# redundant "." segments and safe ".." traversals which normalise away.
+_INSIDE_DIR = _inside_dir()
 
 
 def _manifest_string(components: list[str]) -> str:

--- a/tests/unit/test_bump_lockfiles.py
+++ b/tests/unit/test_bump_lockfiles.py
@@ -7,12 +7,13 @@ import dataclasses as dc
 import operator
 import pathlib
 import shlex
+import string
 import tempfile
 import typing as typ
 from pathlib import Path
 
 import pytest
-from hypothesis import given, settings
+from hypothesis import assume, given, settings
 from hypothesis import strategies as st
 
 from lading.commands import bump_lockfiles
@@ -273,6 +274,102 @@ def test_regenerate_lockfiles_wraps_runner_exceptions(tmp_path: Path) -> None:
         )
 
     assert isinstance(exc_info.value.__cause__, OSError)
+
+
+# ---------------------------------------------------------------------------
+# Hypothesis property tests for manifest-path resolution (issue #93)
+# ---------------------------------------------------------------------------
+
+_segment = st.text(
+    alphabet=string.ascii_lowercase + string.digits + "_-",
+    min_size=1,
+    max_size=10,
+)
+
+# Relative directory paths that stay inside the workspace, optionally with
+# redundant "." segments which normalise away.
+_inside_dir = st.lists(
+    st.one_of(_segment, st.just(".")),
+    min_size=0,
+    max_size=4,
+)
+
+
+def _manifest_string(components: list[str]) -> str:
+    """Render a manifest path string from directory ``components``."""
+    return "/".join((*components, "Cargo.toml"))
+
+
+@given(dirs=st.lists(_inside_dir, max_size=6))
+@settings(max_examples=60, deadline=None)
+def test_inside_manifests_resolve_to_sibling_lockfiles(
+    dirs: list[list[str]],
+) -> None:
+    """Any in-workspace manifest string yields a sibling Cargo.lock path.
+
+    Also pins the ordering and deduplication invariants: the workspace root
+    lockfile is always first, and resolved paths are unique.
+    """
+    with tempfile.TemporaryDirectory(prefix="lading-bump-lockfiles-") as tmp:
+        workspace_root = Path(tmp)
+        manifests = [_manifest_string(components) for components in dirs]
+
+        lockfiles = bump_lockfiles.resolve_lockfile_paths(workspace_root, manifests)
+
+        resolved_root = workspace_root.resolve()
+        assert lockfiles[0] == resolved_root / "Cargo.lock"
+        assert len(set(lockfiles)) == len(lockfiles)
+        for lockfile_path in lockfiles:
+            assert lockfile_path.name == "Cargo.lock"
+            assert lockfile_path.parent == lockfile_path.parent.resolve()
+            lockfile_path.relative_to(resolved_root)
+        expected = {resolved_root / "Cargo.lock"} | {
+            (workspace_root.joinpath(*components, "Cargo.toml")).resolve().parent
+            / "Cargo.lock"
+            for components in dirs
+        }
+        assert set(lockfiles) == expected
+
+
+@given(spellings=st.lists(st.sampled_from(["Cargo.toml", "./Cargo.toml"]), max_size=4))
+@settings(max_examples=20, deadline=None)
+def test_root_manifest_spellings_deduplicate_to_one_invocation(
+    spellings: list[str],
+) -> None:
+    """Every spelling of the root manifest produces exactly one root entry."""
+    with tempfile.TemporaryDirectory(prefix="lading-bump-lockfiles-") as tmp:
+        workspace_root = Path(tmp)
+
+        lockfiles = bump_lockfiles.resolve_lockfile_paths(workspace_root, spellings)
+
+        assert lockfiles == (workspace_root.resolve() / "Cargo.lock",)
+
+
+@given(
+    escape_depth=st.integers(min_value=1, max_value=3),
+    suffix=st.lists(_segment, max_size=2),
+)
+@settings(max_examples=30, deadline=None)
+def test_escaping_manifests_are_rejected(
+    escape_depth: int,
+    suffix: list[str],
+) -> None:
+    """Any manifest path escaping the workspace root raises an error."""
+    with tempfile.TemporaryDirectory(prefix="lading-bump-lockfiles-") as tmp:
+        # Anchor inside a subdirectory so ".." segments cannot accidentally
+        # resolve back inside the temporary root.
+        workspace_root = Path(tmp) / "workspace"
+        workspace_root.mkdir()
+        # A suffix re-entering the workspace directory would resolve back
+        # inside and legitimately pass validation; exclude that case.
+        assume(suffix[:1] != ["workspace"])
+        escaping = "/".join(([".."] * escape_depth) + [*suffix, "Cargo.toml"])
+
+        with pytest.raises(
+            bump_lockfiles.LockfileRegenerationError,
+            match="must stay within the workspace",
+        ):
+            bump_lockfiles.resolve_lockfile_paths(workspace_root, (escaping,))
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_bump_lockfiles.py
+++ b/tests/unit/test_bump_lockfiles.py
@@ -280,7 +280,7 @@ def test_regenerate_lockfiles_wraps_runner_exceptions(tmp_path: Path) -> None:
 # Hypothesis property tests for manifest-path resolution (issue #93)
 # ---------------------------------------------------------------------------
 
-_segment = st.text(
+_SEGMENT = st.text(
     alphabet=string.ascii_lowercase + string.digits + "_-",
     min_size=1,
     max_size=10,
@@ -288,8 +288,8 @@ _segment = st.text(
 
 # Relative directory paths that stay inside the workspace, optionally with
 # redundant "." segments which normalise away.
-_inside_dir = st.lists(
-    st.one_of(_segment, st.just(".")),
+_INSIDE_DIR = st.lists(
+    st.one_of(_SEGMENT, st.just(".")),
     min_size=0,
     max_size=4,
 )
@@ -300,7 +300,7 @@ def _manifest_string(components: list[str]) -> str:
     return "/".join((*components, "Cargo.toml"))
 
 
-@given(dirs=st.lists(_inside_dir, max_size=6))
+@given(dirs=st.lists(_INSIDE_DIR, max_size=6))
 @settings(max_examples=60, deadline=None)
 def test_inside_manifests_resolve_to_sibling_lockfiles(
     dirs: list[list[str]],
@@ -317,18 +317,39 @@ def test_inside_manifests_resolve_to_sibling_lockfiles(
         lockfiles = bump_lockfiles.resolve_lockfile_paths(workspace_root, manifests)
 
         resolved_root = workspace_root.resolve()
-        assert lockfiles[0] == resolved_root / "Cargo.lock"
-        assert len(set(lockfiles)) == len(lockfiles)
+        assert lockfiles[0] == resolved_root / "Cargo.lock", (
+            "workspace root Cargo.lock must be the first resolved lockfile"
+        )
+        assert len(set(lockfiles)) == len(lockfiles), (
+            "resolved lockfiles must be unique"
+        )
         for lockfile_path in lockfiles:
-            assert lockfile_path.name == "Cargo.lock"
-            assert lockfile_path.parent == lockfile_path.parent.resolve()
-            lockfile_path.relative_to(resolved_root)
-        expected = {resolved_root / "Cargo.lock"} | {
-            (workspace_root.joinpath(*components, "Cargo.toml")).resolve().parent
-            / "Cargo.lock"
-            for components in dirs
-        }
-        assert set(lockfiles) == expected
+            assert lockfile_path.name == "Cargo.lock", (
+                f"resolved path must be a sibling Cargo.lock: {lockfile_path}"
+            )
+            assert lockfile_path.parent == lockfile_path.parent.resolve(), (
+                f"lockfile parent must be a normalised path: {lockfile_path}"
+            )
+            assert lockfile_path.is_relative_to(resolved_root), (
+                f"lockfile must stay within the workspace root: {lockfile_path}"
+            )
+        # Build the expected ordered tuple: the workspace root Cargo.lock first,
+        # then the sibling lockfile for each manifest in execution order, with
+        # duplicates removed while preserving that order.
+        expected = tuple(
+            dict.fromkeys(
+                [resolved_root / "Cargo.lock"]
+                + [
+                    workspace_root.joinpath(*components, "Cargo.toml").resolve().parent
+                    / "Cargo.lock"
+                    for components in dirs
+                ]
+            )
+        )
+        assert lockfiles == expected, (
+            "resolved lockfiles must preserve manifest execution order "
+            "without duplicates"
+        )
 
 
 @given(spellings=st.lists(st.sampled_from(["Cargo.toml", "./Cargo.toml"]), max_size=4))
@@ -347,7 +368,7 @@ def test_root_manifest_spellings_deduplicate_to_one_invocation(
 
 @given(
     escape_depth=st.integers(min_value=1, max_value=3),
-    suffix=st.lists(_segment, max_size=2),
+    suffix=st.lists(_SEGMENT, max_size=2),
 )
 @settings(max_examples=30, deadline=None)
 def test_escaping_manifests_are_rejected(


### PR DESCRIPTION
## Summary

Closes #93

Property tests covering the four invariants of manifest-path resolution in `bump_lockfiles`:

- **Path normalisation** — arbitrary in-workspace manifest strings (including redundant `.` segments) always produce a normalised sibling `Cargo.lock` path inside the workspace.
- **Deduplication** — every spelling of the workspace root manifest (`Cargo.toml`, `./Cargo.toml`, repeated) produces exactly one root entry.
- **Ordering invariant** — the workspace root `Cargo.lock` is always the first element, regardless of input order; resolved paths are unique.
- **Rejection invariant** — any manifest path escaping the workspace root raises `LockfileRegenerationError`. The escape test anchors the workspace in a subdirectory and excludes (via `assume`) the degenerate suffix that would legitimately resolve back inside.

## Testing

- `make check-fmt`, `make lint`, `make typecheck`, and `make test` (697 passed) all green after rebasing onto current `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Add property-based tests to verify manifest path resolution behavior in bump_lockfiles, including normalization, deduplication, ordering, and rejection of paths escaping the workspace root.

Tests:
- Introduce Hypothesis-based property tests ensuring in-workspace manifests resolve to normalized sibling Cargo.lock files with unique paths and correct ordering.
- Add tests confirming multiple spellings of the workspace root manifest deduplicate to a single root Cargo.lock entry.
- Add tests asserting that manifest paths attempting to escape the workspace root are rejected with LockfileRegenerationError.

## References

- Lody session: https://lody.ai/leynos/sessions/47cdf895-d6fd-46e2-aaec-00258f986cc4
