### PR TITLE
Record design review of publication pipeline helpers (#72)

### DIFF
--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -563,6 +563,16 @@ stderr-tail diagnostics. `_run_preflight_checks` builds these option objects for
 `cargo check` and `cargo test` so command construction stays explicit and
 testable.
 
+Design review (issue #72): `_dispatch_publication` and
+`_PublicationPipelineState` were assessed after contradictory static-analysis
+advice (one finding asked for the extraction; another called the bundle and the
+wrapper unnecessary). Both stay. `_dispatch_publication` owns the pipeline-mode
+logging and the dry-run two-phase sequencing, keeps `run()` linear, and is the
+seam the dispatch tests exercise directly. `_PublicationPipelineState` keeps
+the per-crate helper signatures within the four-argument lint ceiling and pins
+the invariant that plan, preparation, and options are constructed together and
+immutable for the pipeline's lifetime.
+
 Publication dispatch deliberately differs by mode. Dry-run mode keeps the
 historical two-phase pipeline: package every publishable crate, then run
 `cargo publish --dry-run` for every crate. Live mode interleaves the pipeline

--- a/lading/commands/publish.py
+++ b/lading/commands/publish.py
@@ -134,7 +134,16 @@ class _PublishExecutionOptions:
 
 @dc.dataclass(frozen=True, slots=True)
 class _PublicationPipelineState:
-    """Shared publish state for cargo package and publish invocations."""
+    """Shared publish state for cargo package and publish invocations.
+
+    Design note (issue #72): this bundle is deliberate. The per-crate
+    helpers (``_package_crate``, ``_publish_crate``) would otherwise need
+    ``plan``, ``preparation``, and ``options`` threaded individually,
+    pushing their signatures past the argument-count lint ceiling and
+    inviting positional mix-ups. The three fields are constructed together
+    in each pipeline entry point and are immutable for the pipeline's
+    lifetime, which is the invariant the dataclass enforces.
+    """
 
     plan: PublishPlan
     preparation: PublishPreparation
@@ -644,7 +653,15 @@ def _dispatch_publication(
     options: _PublishExecutionOptions,
     runner: CommandRunner,
 ) -> None:
-    """Route to the live or dry-run publication pipeline."""
+    """Route to the live or dry-run publication pipeline.
+
+    Design note (issue #72): this helper is more than a relocated branch.
+    It owns the operator-facing pipeline-mode log line, sequences the
+    dry-run two-phase pipeline (package everything, then publish
+    everything), and gives tests a single seam to exercise mode dispatch
+    without driving ``run()`` end to end. Inlining it would push ``run()``
+    back toward the complexity ceiling that prompted the extraction.
+    """
     if options.live:
         LOGGER.info("Publication mode: live (interleaved per-crate pipeline)")
         _execute_live_publication_pipeline(


### PR DESCRIPTION
## Summary

Closes #72

PR #70 extracted `_dispatch_publication` to reduce `run()`'s cyclomatic complexity; a separate static-analysis check argued the opposite — that `_PublicationPipelineContext` (now `_PublicationPipelineState`) bundles parameters without invariants and the dispatcher wraps a single branch. This PR resolves the contradiction deliberately.

**Conclusion: keep both**, and record why so the contradiction does not resurface:

- `_dispatch_publication` owns the operator-facing pipeline-mode log line, sequences the dry-run two-phase pipeline, keeps `run()` linear under the C901 ceiling, and is the seam the dispatch tests exercise directly. Inlining it would shift the branch without removing it.
- `_PublicationPipelineState` keeps the per-crate helper signatures (`_package_crate`, `_publish_crate`) within the four-argument lint ceiling and enforces the invariant that plan, preparation, and options are constructed together and immutable for the pipeline's lifetime.

The rationale is captured in both docstrings and `docs/developers-guide.md`. No behavioural change.

## Testing

- Existing dispatch/pipeline tests already cover the seams; no behaviour changed.
- `make check-fmt`, `make lint`, `make typecheck`, and `make test` (561 passed) all green after rebasing onto current `main`.
- `coderabbit review --agent`: 0 findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Document the design rationale for keeping the publication pipeline helper abstractions without changing runtime behavior.

Enhancements:
- Add design notes to `_PublicationPipelineState` explaining its role in bundling immutable pipeline state and keeping helper signatures within lint limits.
- Expand `_dispatch_publication` docstring to clarify its responsibilities for logging, dry-run sequencing, complexity management, and test seams.
- Record the publication pipeline design review and conclusions in the developer guide, including the reasoning for retaining both helpers despite static-analysis suggestions.