### PR TITLE
Skip the workflow contract test inside mutmut's sandbox

### DIFF
--- a/tests/workflow_contracts/test_mutation_testing.py
+++ b/tests/workflow_contracts/test_mutation_testing.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 import typing as typ
 from pathlib import Path
 
+import pytest
 import yaml
 
 WORKFLOW_PATH = (
@@ -21,6 +22,14 @@ WORKFLOW_PATH = (
     / ".github"
     / "workflows"
     / "mutation-testing.yml"
+)
+
+pytestmark = pytest.mark.skipif(
+    not WORKFLOW_PATH.exists(),
+    reason=(
+        "workflow file not present in this working copy (for example "
+        "inside mutmut's mutants/ sandbox, which does not copy .github/)"
+    ),
 )
 
 #: The pinned commit of leynos/shared-actions providing


### PR DESCRIPTION
## What

Adds a module-level `pytestmark = pytest.mark.skipif(...)` guard to the workflow contract test, keyed on the existence of the mutation-testing caller workflow file. No assertion is changed.

## Why

mutmut copies the project into a `mutants/` working directory before running its baseline, and that copy does not include `.github/`. The contract test then fails with `FileNotFoundError`, mutmut treats the baseline as failing, and the whole mutation run aborts. Observed live in the scheduled mutation run for leynos/polythene (actions run 28854071831).

With the guard, the test still runs with unchanged assertions in a full checkout (including pull-request CI), and is skipped only in working copies that lack the workflow file, such as mutmut's sandbox.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
