### PR TITLE
Wire CodeScene coverage upload and ratchet

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,10 @@ jobs:
     steps:
       - name: Check out repository
         uses: actions/checkout@v7
+        with:
+          # Full history so a future `cs-coverage check` can reach the
+          # pull request's merge base (see the deferred gate note below).
+          fetch-depth: 0
 
       - name: Set up Python
         uses: actions/setup-python@v6
@@ -47,38 +51,28 @@ jobs:
       - name: Run typechecker
         run: make typecheck
 
-      - name: Run tests with coverage
-        run: |
-          uv pip install slipcover pytest-forked
-          uv run python -m slipcover \
-            --source=./lading \
-            --omit="*/.venv/*" \
-            --branch \
-            --out coverage.xml \
-            -m pytest --forked -v
-
-      - name: Upload coverage artifact
-        uses: actions/upload-artifact@v4
+      # Coverage runs on pull requests only. Pushes to main upload their
+      # own coverage (and advance the ratchet baseline) via
+      # coverage-main.yml, so generating it here as well would duplicate
+      # the work and the CodeScene upload for the same commit.
+      - name: Generate coverage
+        if: github.event_name == 'pull_request'
+        uses: leynos/shared-actions/.github/actions/generate-coverage@927edd45ae77be4251a8a18ca9eb5613a2e32cbd
         with:
-          name: coverage
-          path: coverage.xml
-
-      - name: Install CodeScene Coverage CLI
-        if: env.CS_ACCESS_TOKEN != ''
-        run: |
-          curl -fsSL https://downloads.codescene.io/enterprise/cli/install-cs-coverage-tool.sh | bash -s -- -y
-          if [ -n "${CODESCENE_CLI_SHA256:-}" ]; then
-            echo "${CODESCENE_CLI_SHA256}  install-cs-coverage-tool.sh" | sha256sum -c -
-          fi
-
-      - name: Upload coverage to CodeScene
-        if: env.CS_ACCESS_TOKEN != ''
-        run: |
-          if [ ! -f coverage.xml ]; then
-            echo "coverage.xml not found!"
-            exit 1
-          fi
-          cs-coverage upload \
-            --format "cobertura" \
-            --metric "line-coverage" \
-            coverage.xml
+          output-path: coverage.xml
+          format: cobertura
+          # The suite previously ran under slipcover with pytest-forked
+          # (serial, out-of-process fork isolation per test). The shared
+          # action's serial mode (pytest-workers: '') is in-process, not
+          # forked, so this is not perfectly behaviour-preserving if any
+          # test relies on fork isolation; watch the first CI run.
+          # Follow-up 4 removes this pin to adopt pytest-xdist once the
+          # suite is confirmed xdist-clean.
+          pytest-workers: ''
+          with-ratchet: 'true'
+      # The `mode: check` step is deliberately not wired in yet: the
+      # estate survey found CodeScene's coverage-gates configuration is
+      # enabled only for mxd's project today. Add the check step in a
+      # fast-follow PR once coverage-main.yml has uploaded to main at
+      # least once and the gate is confirmed to resolve, or once
+      # CodeScene confirms this project's coverage gate is enabled.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,9 +8,6 @@ on:
 jobs:
   lint-test:
     runs-on: ubuntu-latest
-    env:
-      CS_ACCESS_TOKEN: ${{ secrets.CS_ACCESS_TOKEN }}
-      CODESCENE_CLI_SHA256: ${{ vars.CODESCENE_CLI_SHA256 }}
     steps:
       - name: Check out repository
         uses: actions/checkout@v7
@@ -51,28 +48,41 @@ jobs:
       - name: Run typechecker
         run: make typecheck
 
-      # Coverage runs on pull requests only. Pushes to main upload their
-      # own coverage (and advance the ratchet baseline) via
-      # coverage-main.yml, so generating it here as well would duplicate
-      # the work and the CodeScene upload for the same commit.
-      - name: Generate coverage
-        if: github.event_name == 'pull_request'
-        uses: leynos/shared-actions/.github/actions/generate-coverage@927edd45ae77be4251a8a18ca9eb5613a2e32cbd
+      # NOTE: the shared generate-coverage action is not used here. Its
+      # language auto-detection treats any repository-root Cargo.toml as
+      # Rust (or "mixed" alongside pyproject.toml) with no override, and
+      # lading commits a synthetic root Cargo.toml as a fixture for its
+      # own workspace-release test scenarios (see
+      # docs/repository-layout.md) — it references crates/ directories
+      # that do not exist on disk. `cargo llvm-cov nextest --workspace`
+      # therefore fails immediately in CI trying to resolve that
+      # manifest. Coverage generation stays on the pre-existing bespoke
+      # slipcover invocation until the shared action supports a
+      # language override; the CodeScene wiring layers the shared
+      # upload-codescene-coverage action on top of this coverage.xml
+      # instead.
+      - name: Run tests with coverage
+        run: |
+          uv pip install slipcover pytest-forked
+          uv run python -m slipcover \
+            --source=./lading \
+            --omit="*/.venv/*" \
+            --branch \
+            --out coverage.xml \
+            -m pytest --forked -v
+
+      - name: Upload coverage artifact
+        uses: actions/upload-artifact@v4
         with:
-          output-path: coverage.xml
-          format: cobertura
-          # The suite previously ran under slipcover with pytest-forked
-          # (serial, out-of-process fork isolation per test). The shared
-          # action's serial mode (pytest-workers: '') is in-process, not
-          # forked, so this is not perfectly behaviour-preserving if any
-          # test relies on fork isolation; watch the first CI run.
-          # Follow-up 4 removes this pin to adopt pytest-xdist once the
-          # suite is confirmed xdist-clean.
-          pytest-workers: ''
-          with-ratchet: 'true'
-      # The `mode: check` step is deliberately not wired in yet: the
-      # estate survey found CodeScene's coverage-gates configuration is
-      # enabled only for mxd's project today. Add the check step in a
-      # fast-follow PR once coverage-main.yml has uploaded to main at
-      # least once and the gate is confirmed to resolve, or once
-      # CodeScene confirms this project's coverage gate is enabled.
+          name: coverage
+          path: coverage.xml
+
+      # CodeScene accepts `cs-coverage upload` only for analysed branches
+      # (main), so no upload happens on pull requests; coverage-main.yml
+      # uploads on push to main instead. The `mode: check` changed-line
+      # gate is deliberately not wired in either: the estate survey
+      # found CodeScene's coverage-gates configuration is enabled only
+      # for mxd's project today. Add the check step in a fast-follow PR
+      # once coverage-main.yml has uploaded to main at least once and
+      # the gate is confirmed to resolve, or once CodeScene confirms
+      # this project's coverage gate is enabled.

--- a/.github/workflows/coverage-main.yml
+++ b/.github/workflows/coverage-main.yml
@@ -1,0 +1,52 @@
+name: Coverage (main)
+
+# CodeScene accepts `cs-coverage upload` only for analysed branches, so
+# main-branch coverage is uploaded here on push; pull requests run the
+# coverage generation (and, in a future fast-follow, the changed-line
+# `cs-coverage check` gate) in ci.yml instead. This workflow also
+# advances the coverage ratchet baseline: caches saved on main are
+# readable by every pull-request run, so the baseline written here is
+# the one PR ratchet checks compare against.
+
+on:
+  push:
+    branches: [main]
+
+jobs:
+  coverage-upload:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    env:
+      CS_ACCESS_TOKEN: ${{ secrets.CS_ACCESS_TOKEN || '' }}
+      CODESCENE_CLI_SHA256: ${{ vars.CODESCENE_CLI_SHA256 || '' }}
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v7
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.13'
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+
+      - name: Generate coverage
+        uses: leynos/shared-actions/.github/actions/generate-coverage@927edd45ae77be4251a8a18ca9eb5613a2e32cbd
+        with:
+          output-path: coverage.xml
+          format: cobertura
+          # Keep the run serial to match the pull-request coverage job;
+          # see the note in ci.yml.
+          pytest-workers: ''
+          with-ratchet: 'true'
+
+      - name: Upload coverage data to CodeScene
+        if: env.CS_ACCESS_TOKEN
+        uses: leynos/shared-actions/.github/actions/upload-codescene-coverage@927edd45ae77be4251a8a18ca9eb5613a2e32cbd
+        with:
+          format: cobertura
+          path: coverage.xml
+          access-token: ${{ env.CS_ACCESS_TOKEN }}
+          installer-checksum: ${{ env.CODESCENE_CLI_SHA256 }}

--- a/.github/workflows/coverage-main.yml
+++ b/.github/workflows/coverage-main.yml
@@ -2,11 +2,21 @@ name: Coverage (main)
 
 # CodeScene accepts `cs-coverage upload` only for analysed branches, so
 # main-branch coverage is uploaded here on push; pull requests run the
-# coverage generation (and, in a future fast-follow, the changed-line
-# `cs-coverage check` gate) in ci.yml instead. This workflow also
-# advances the coverage ratchet baseline: caches saved on main are
-# readable by every pull-request run, so the baseline written here is
-# the one PR ratchet checks compare against.
+# lint-test suite (and, in a future fast-follow, the changed-line
+# `cs-coverage check` gate) in ci.yml instead, without an upload.
+#
+# NOTE: coverage generation uses the pre-existing bespoke slipcover
+# invocation, not the shared generate-coverage action. lading's root
+# Cargo.toml is a committed fixture for its own workspace-release test
+# scenarios (see docs/repository-layout.md), not a buildable crate; the
+# shared action's language auto-detection has no override and always
+# treats a root Cargo.toml as Rust (or "mixed" alongside pyproject.toml),
+# so it tries `cargo llvm-cov nextest --workspace` against members that
+# do not exist on disk and fails immediately. Consequently this workflow
+# cannot use generate-coverage's with-ratchet baseline either — the
+# ratchet is implemented inside that action. The coverage ratchet is
+# skipped for lading until the shared action gains a language override
+# (see the CodeScene coverage rollout notes).
 
 on:
   push:
@@ -32,15 +42,15 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@v5
 
-      - name: Generate coverage
-        uses: leynos/shared-actions/.github/actions/generate-coverage@927edd45ae77be4251a8a18ca9eb5613a2e32cbd
-        with:
-          output-path: coverage.xml
-          format: cobertura
-          # Keep the run serial to match the pull-request coverage job;
-          # see the note in ci.yml.
-          pytest-workers: ''
-          with-ratchet: 'true'
+      - name: Run tests with coverage
+        run: |
+          uv pip install slipcover pytest-forked
+          uv run python -m slipcover \
+            --source=./lading \
+            --omit="*/.venv/*" \
+            --branch \
+            --out coverage.xml \
+            -m pytest --forked -v
 
       - name: Upload coverage data to CodeScene
         if: env.CS_ACCESS_TOKEN
@@ -48,5 +58,6 @@ jobs:
         with:
           format: cobertura
           path: coverage.xml
+          mode: upload
           access-token: ${{ env.CS_ACCESS_TOKEN }}
           installer-checksum: ${{ env.CODESCENE_CLI_SHA256 }}

--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -28,6 +28,6 @@ jobs:
       # The token is not used for any external cloud auth.
       id-token: write
     if: ${{ github.event_name == 'workflow_dispatch' || github.actor == 'dependabot[bot]' }}
-    uses: leynos/shared-actions/.github/workflows/dependabot-automerge.yml@d28e04c9ea359650a85d697d1ab3d0be0b5674e7
+    uses: leynos/shared-actions/.github/workflows/dependabot-automerge.yml@927edd45ae77be4251a8a18ca9eb5613a2e32cbd
     with:
       pull-request-number: ${{ inputs.pull-request-number || github.event.pull_request.number }}

--- a/.github/workflows/mutation-testing.yml
+++ b/.github/workflows/mutation-testing.yml
@@ -18,7 +18,7 @@ jobs:
     permissions:
       contents: read
       id-token: write # OIDC workflow-source resolution
-    uses: leynos/shared-actions/.github/workflows/mutation-mutmut.yml@47aea18960d24f33aedc4782ec6b73e365418313
+    uses: leynos/shared-actions/.github/workflows/mutation-mutmut.yml@927edd45ae77be4251a8a18ca9eb5613a2e32cbd
     with:
       # Flat layout: the mutable source lives in lading/, not src/.
       paths: "lading/"

--- a/tests/workflow_contracts/test_mutation_testing.py
+++ b/tests/workflow_contracts/test_mutation_testing.py
@@ -34,7 +34,7 @@ pytestmark = pytest.mark.skipif(
 
 #: The pinned commit of leynos/shared-actions providing
 #: mutation-mutmut.yml. Bump the workflow and this test together.
-PINNED_SHA = "47aea18960d24f33aedc4782ec6b73e365418313"
+PINNED_SHA = "927edd45ae77be4251a8a18ca9eb5613a2e32cbd"
 
 EXPECTED_USES = (
     "leynos/shared-actions/.github/workflows/mutation-mutmut.yml@" + PINNED_SHA


### PR DESCRIPTION
## Summary

Onboards lading to the estate CodeScene coverage flow.

- Adds [`coverage-main.yml`](https://github.com/leynos/lading/blob/codescene-coverage-gate/.github/workflows/coverage-main.yml):
  on push to `main` it regenerates coverage and uploads it to
  CodeScene (the only branch CodeScene accepts uploads for) via the
  shared
  [`upload-codescene-coverage`](https://github.com/leynos/shared-actions/tree/927edd45ae77be4251a8a18ca9eb5613a2e32cbd/.github/actions/upload-codescene-coverage)
  action, replacing the bespoke `curl | bash` installer and
  `cs-coverage upload` call that used to live (and run redundantly on
  every pull request) in `ci.yml`.
- [`ci.yml`](https://github.com/leynos/lading/blob/codescene-coverage-gate/.github/workflows/ci.yml)
  now checks out with `fetch-depth: 0` (for a future changed-line
  gate) and no longer uploads coverage anywhere — CodeScene only
  accepts uploads for `main`, so the previous PR-time upload attempt
  was always a silent no-op.
- Bumps every `leynos/shared-actions` reference to
  `927edd45ae77be4251a8a18ca9eb5613a2e32cbd` as a single repo-wide
  pin — the coverage actions require it — including the
  mutation-testing and dependabot-automerge callers, and updates the
  workflow-contract test.

The `CodeScene Code Coverage` check is **not** a required check and
does not appear in the branch ruleset (which requires only
`lint-test`). CodeScene posts it on every pull-request head once its
coverage gate is enabled for a project, and it influences the status
rollup, which is what the Dependabot automerge gate reads. Wiring the
upload now means that check resolves instead of hanging once the gate
is switched on CodeScene-side.

### Deviation: the shared `generate-coverage` action is not used

lading's repository root carries a committed `Cargo.toml` that is a
deliberate fixture for its own workspace-release test scenarios (see
`docs/repository-layout.md`) — it references `crates/` directories
that do not exist on disk and is not meant to be built by Cargo
directly. The shared `generate-coverage` action's language
auto-detection unconditionally treats a root `Cargo.toml` as Rust (or
"mixed" alongside `pyproject.toml`), with no override input, so it ran
`cargo llvm-cov nextest --workspace` against that fixture and failed
immediately (confirmed on the first CI run of this PR).

Coverage generation therefore stays on the pre-existing bespoke
slipcover invocation in both `ci.yml` and `coverage-main.yml`; only the
CodeScene upload step moves to the shared
`upload-codescene-coverage` action, which does no language detection.
One consequence: the coverage ratchet (`with-ratchet`) lives inside
`generate-coverage`, so it is **not enabled** for lading — it can be
added once the shared action gains a language override (or once the
root fixture is relocated, which is out of scope here).

### Deferred gate

The `mode: check` changed-line gate is deliberately **not** wired in
yet. The estate survey found CodeScene's coverage-gates configuration
is enabled only for one project (mxd) today; wiring `mode: check`
elsewhere fails every run with "the received project-config isn't
valid. Lacks the gates configuration." — a CodeScene-side per-project
setting, not a CI defect. It joins a fast-follow PR once the gate is
enabled for this project (CodeScene project 72980) and
`coverage-main.yml` has uploaded from `main` at least once.

### Behaviour-preserving choices

- **Cobertura.** The pipeline was already cobertura throughout
  (`coverage.xml`); kept rather than switching to lcov.
- **Coverage generation is unchanged.** Same slipcover invocation,
  same `--source`/`--omit` scoping, same `pytest --forked`, in both
  workflows.

## Review walkthrough

- [`.github/workflows/ci.yml`](https://github.com/leynos/lading/blob/codescene-coverage-gate/.github/workflows/ci.yml)
  — `fetch-depth: 0`; drops the PR-time CodeScene upload attempt
  (always a no-op against a non-analysed branch); deferred-gate note
  in place of the check step.
- [`.github/workflows/coverage-main.yml`](https://github.com/leynos/lading/blob/codescene-coverage-gate/.github/workflows/coverage-main.yml)
  — new push-to-main job: bespoke slipcover generation, then the
  shared `upload-codescene-coverage` action with `mode: upload`.
- [`.github/workflows/mutation-testing.yml`](https://github.com/leynos/lading/blob/codescene-coverage-gate/.github/workflows/mutation-testing.yml)
  and [`.github/workflows/dependabot-automerge.yml`](https://github.com/leynos/lading/blob/codescene-coverage-gate/.github/workflows/dependabot-automerge.yml)
  — pin bumped to the single repo-wide SHA.
- [`tests/workflow_contracts/test_mutation_testing.py`](https://github.com/leynos/lading/blob/codescene-coverage-gate/tests/workflow_contracts/test_mutation_testing.py)
  — `PINNED_SHA` updated to match the mutation caller.

## Validation

- `python3 -c "import yaml; ..."` parses all workflow files.
- `uv run pytest tests/workflow_contracts` — 6 passed.
- Repository CI (`lint-test`) on this PR head.
