### PR TITLE
Build the virtual environment before generating main coverage

### DIFF
--- a/.github/workflows/coverage-main.yml
+++ b/.github/workflows/coverage-main.yml
@@ -42,6 +42,9 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@v5
 
+      - name: Install code
+        run: make build
+
       - name: Run tests with coverage
         run: |
           uv pip install slipcover pytest-forked


### PR DESCRIPTION
coverage-main.yml's first run on main failed: `uv pip install` requires an active virtual environment, but the job never created one before that step. ci.yml runs `make build` (`uv sync --group dev`) first; add the same step here so both coverage-generation paths stay in step.

## Validation

- `python3 -c "import yaml; ..."` parses the workflow file.
- Repository CI (`lint-test`) on this PR head.