### PR TITLE
Pass --xml so slipcover produces Cobertura, not plain text

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,7 +60,9 @@ jobs:
       # slipcover invocation until the shared action supports a
       # language override; the CodeScene wiring layers the shared
       # upload-codescene-coverage action on top of this coverage.xml
-      # instead.
+      # instead. Adds --xml: without it slipcover's --out target is a
+      # plain-text report, not Cobertura XML, which went unnoticed
+      # while the CodeScene upload step was guarded by an unset secret.
       - name: Run tests with coverage
         run: |
           uv pip install slipcover pytest-forked
@@ -68,6 +70,7 @@ jobs:
             --source=./lading \
             --omit="*/.venv/*" \
             --branch \
+            --xml \
             --out coverage.xml \
             -m pytest --forked -v
 

--- a/.github/workflows/coverage-main.yml
+++ b/.github/workflows/coverage-main.yml
@@ -45,6 +45,11 @@ jobs:
       - name: Install code
         run: make build
 
+      # --xml is required: without it slipcover's --out target is a
+      # plain-text report, not Cobertura XML, which went unnoticed
+      # while the CodeScene upload step was guarded by an unset secret
+      # (confirmed by this workflow's first live run failing to parse
+      # the uploaded coverage data).
       - name: Run tests with coverage
         run: |
           uv pip install slipcover pytest-forked
@@ -52,6 +57,7 @@ jobs:
             --source=./lading \
             --omit="*/.venv/*" \
             --branch \
+            --xml \
             --out coverage.xml \
             -m pytest --forked -v
 


### PR DESCRIPTION
coverage-main.yml's first successful test run still failed at the upload step: CodeScene rejected `coverage.xml` with "Content is not allowed in prolog." Without `--xml`, slipcover's `--out` target is a plain-text coverage report, not Cobertura XML — a pre-existing bug in the bespoke invocation (present before this rollout) that went unnoticed because the previous CodeScene upload step was guarded by an unset `CS_ACCESS_TOKEN` and never actually ran against real content. Adds `--xml` in both `ci.yml` and `coverage-main.yml`.

Verified locally: `slipcover --xml --out coverage.xml` produces a well-formed `<coverage ...>` document; without `--xml` the same command wrote a plain-text table instead.

## Validation

- `python3 -c "import yaml; ..."` parses both workflow files.
- Local slipcover run confirms `--xml` output starts with a valid XML declaration and `<coverage>` root element.
- Repository CI (`lint-test`) on this PR head.