### PR TITLE
Stop pinning the mutation-testing caller's exact commit SHA

### DIFF
--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -104,6 +104,42 @@ The end-to-end suite in `tests/e2e/` keeps git interactions real while stubbing
 only `cargo` operations, using cmd-mox passthrough spies for `git status` when
 publish runs with stub mode enabled.
 
+## Workflow pins and Dependabot
+
+Dependabot owns the upgrade of GitHub Actions and reusable workflows,
+including calls into `leynos/shared-actions`. Contract tests that assert a
+caller's exact commit SHA create a lockstep dependency: every time Dependabot
+opens a bump PR, the test fails until a human edits the pinned constant to
+match. That defeats the purpose of automated dependency updates and turns a
+routine bump into a manual chore.
+
+Contract tests may still verify the _shape_ of a reusable-workflow caller.
+They must not verify the specific SHA value.
+
+- Do assert the workflow references the correct reusable workflow path.
+- Do assert the ref is pinned to a full 40-character commit SHA, not a
+  mutable branch such as `main` or `rolling`.
+- Do assert the expected `on:` triggers, least-privilege `permissions:`, and
+  the inputs the caller relies on.
+- Do not hard-code the current SHA value as an expected string. Match it with
+  a pattern instead.
+- Do not fail a test purely because Dependabot bumped the pinned SHA.
+
+```python
+import re
+
+SHA_RE = re.compile(r"^[0-9a-f]{40}$")
+
+
+def test_uses_pinned_full_sha(caller_step):
+    ref = caller_step["uses"].split("@")[-1]
+    assert SHA_RE.match(ref), f"expected a 40-hex commit SHA, got {ref!r}"
+```
+
+If a workflow's behaviour genuinely depends on a feature only present from a
+particular commit onwards, express that as a comment or a changelog note, not
+as a test assertion on the SHA string.
+
 ## Property-based testing
 
 [Hypothesis](https://hypothesis.readthedocs.io/) is a development dependency

--- a/tests/workflow_contracts/test_mutation_testing.py
+++ b/tests/workflow_contracts/test_mutation_testing.py
@@ -7,10 +7,16 @@ tests parse the caller with PyYAML and pin the contract it must uphold,
 so drift (repointing the pin at a branch, widening permissions, or
 losing the flat-layout configuration) fails CI on the pull request
 rather than surfacing in a scheduled or manual run.
+
+The caller must reference the correct reusable workflow at a commit SHA;
+Dependabot owns the SHA value, so these tests assert the shape of the
+pin (the workflow path and a full 40-hex commit SHA) rather than the
+specific commit.
 """
 
 from __future__ import annotations
 
+import re
 import typing as typ
 from pathlib import Path
 
@@ -32,12 +38,9 @@ pytestmark = pytest.mark.skipif(
     ),
 )
 
-#: The pinned commit of leynos/shared-actions providing
-#: mutation-mutmut.yml. Bump the workflow and this test together.
-PINNED_SHA = "927edd45ae77be4251a8a18ca9eb5613a2e32cbd"
-
-EXPECTED_USES = (
-    "leynos/shared-actions/.github/workflows/mutation-mutmut.yml@" + PINNED_SHA
+USES_RE = re.compile(
+    r"^leynos/shared-actions/\.github/workflows/mutation-mutmut\.yml@"
+    r"(?P<sha>[0-9a-f]{40})$"
 )
 
 #: The exact caller configuration: lading is a flat-layout package, so
@@ -72,25 +75,20 @@ def _mutation_job(workflow: dict[str, object]) -> dict[str, object]:
     return typ.cast("dict[str, object]", jobs["mutation"])
 
 
-def test_uses_reference_is_pinned_to_the_documented_sha() -> None:
-    """The job must call the shared workflow at the exact documented SHA."""
+def test_uses_reference_is_pinned_to_a_commit_sha() -> None:
+    """The job must call mutation-mutmut.yml pinned to a full commit SHA.
+
+    Dependabot owns the pinned SHA value; this test only guards the shape
+    of the reference (the correct reusable workflow path, pinned to a
+    40-hex commit SHA rather than a mutable branch or tag such as
+    ``main`` or ``rolling``).
+    """
     uses = _mutation_job(_load()).get("uses")
     assert isinstance(uses, str), "jobs.mutation.uses is missing"
-    path, _, ref = uses.partition("@")
-    assert path == "leynos/shared-actions/.github/workflows/mutation-mutmut.yml", (
-        f"jobs.mutation.uses must reference mutation-mutmut.yml, got {path!r}"
-    )
-    assert len(ref) == 40, (
-        f"jobs.mutation.uses must pin a full 40-character commit SHA, "
-        f"not a branch or tag: {ref!r}"
-    )
-    assert all(c in "0123456789abcdef" for c in ref), (
-        f"jobs.mutation.uses must pin a lowercase hex commit SHA, "
-        f"not a branch or tag: {ref!r}"
-    )
-    assert uses == EXPECTED_USES, (
-        f"jobs.mutation.uses pins {ref!r}; this test documents {PINNED_SHA!r} — "
-        "bump both together with the workflow"
+    assert USES_RE.match(uses), (
+        "jobs.mutation.uses must reference "
+        "leynos/shared-actions/.github/workflows/mutation-mutmut.yml "
+        f"pinned to a full 40-hex commit SHA, got {uses!r}"
     )
 
 


### PR DESCRIPTION
## Summary

- Converts the mutation-testing contract test's exact-SHA assertion
  into a shape assertion: it still requires the caller's `uses:` to
  reference `leynos/shared-actions/.github/workflows/mutation-mutmut.yml`
  pinned to a full 40-hex commit SHA, but no longer pins the specific
  commit value.
- Hands ownership of the pinned SHA to Dependabot: its bump PRs no
  longer need a hand-edited test constant to pass CI.
- Documents the policy in the developers' guide so future contract
  tests follow the same shape-not-value convention.

## Review walkthrough

- `tests/workflow_contracts/test_mutation_testing.py`: replaces
  `PINNED_SHA`/`EXPECTED_USES` and the exact-match assertion with a
  `USES_RE` regex requiring the correct workflow path and a 40-hex SHA.
  All other assertions (permissions, workflow-level default
  permissions, concurrency, triggers, `with` block) are untouched.
- `docs/developers-guide.md`: new "Workflow pins and Dependabot"
  section recording the policy and a minimal example.
- `.github/dependabot.yml` already has a `github-actions` ecosystem
  entry with `directory: "/"`, so no change was needed there.

## Validation

- `uv run pytest tests/workflow_contracts/test_mutation_testing.py -v`
  — all 6 tests pass against the workflow's current pinned SHA
  (`927edd45ae77be4251a8a18ca9eb5613a2e32cbd`); the new regex is a
  pattern match with no stored value, so it would equally pass any
  other syntactically valid 40-hex SHA.
- `make check-fmt`, `make lint`, `make typecheck`, `make spelling`,
  `make markdownlint` all pass locally.
