### PR TITLE
Add the CodeScene mode:check coverage gate to lading's PR job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,18 +77,34 @@ jobs:
             --out coverage.xml \
             -m pytest --forked -v
 
+      # Named coverage-report rather than "coverage" because the
+      # upload-codescene-coverage action below unconditionally uploads
+      # the same file as an artifact named "coverage"; sharing the name
+      # makes the second upload fail with a 409 name conflict. Keeping
+      # this standalone upload preserves the coverage artifact on runs
+      # where the gate step is skipped (secret-less fork PRs, and
+      # push-to-main where the gate is PR-only).
       - name: Upload coverage artifact
         uses: actions/upload-artifact@v4
         with:
-          name: coverage
+          name: coverage-report
           path: coverage.xml
 
       # CodeScene accepts `cs-coverage upload` only for analysed branches
       # (main), so no upload happens on pull requests; coverage-main.yml
-      # uploads on push to main instead. The `mode: check` changed-line
-      # gate is deliberately not wired in either: the estate survey
-      # found CodeScene's coverage-gates configuration is enabled only
-      # for mxd's project today. Add the check step in a fast-follow PR
-      # once coverage-main.yml has uploaded to main at least once and
-      # the gate is confirmed to resolve, or once CodeScene confirms
-      # this project's coverage gate is enabled.
+      # uploads on push to main instead. The changed-line gate below
+      # reuses the bespoke coverage.xml generated above (see the note on
+      # the "Run tests with coverage" step for why the shared
+      # generate-coverage action cannot be used here).
+      - name: Check coverage against CodeScene gates
+        env:
+          CS_ACCESS_TOKEN: ${{ secrets.CS_ACCESS_TOKEN }}
+        if: env.CS_ACCESS_TOKEN != '' && github.event_name == 'pull_request'
+        uses: leynos/shared-actions/.github/actions/upload-codescene-coverage@927edd45ae77be4251a8a18ca9eb5613a2e32cbd
+        with:
+          format: cobertura
+          path: coverage.xml
+          mode: check
+          project-url: https://api.codescene.io/v2/projects/72980
+          access-token: ${{ env.CS_ACCESS_TOKEN }}
+          installer-checksum: ${{ vars.CODESCENE_CLI_SHA256 }}


### PR DESCRIPTION
## Summary

- CodeScene's coverage-gates configuration is now enabled for lading's
  project (72980), so the deferred `mode: check` fast-follow can land:
  adds a guarded "Check coverage against CodeScene gates" step to the
  PR coverage job in `ci.yml`, running `cs-coverage check` against the
  bespoke slipcover-generated `coverage.xml`.
- lading keeps its own bespoke slipcover coverage generation rather
  than the shared `generate-coverage` action: the shared action's
  language auto-detection misclassifies lading's fixture root
  `Cargo.toml` as a buildable Rust workspace
  (shared-actions#335), so this PR layers the standalone
  `upload-codescene-coverage` action directly onto the existing
  `coverage.xml`, matching the pattern already used in
  `coverage-main.yml`.
- Replaces the deferred-gate comment the earlier upload-wiring PR left
  in place, now that the gate has been confirmed enabled.

## Review walkthrough

- [`.github/workflows/ci.yml`](https://github.com/leynos/lading/blob/codescene-mode-check/.github/workflows/ci.yml) —
  new guarded step, gated on `CS_ACCESS_TOKEN` being set and the event
  being a pull request; reuses the shared-actions pin
  (`927edd45ae77be4251a8a18ca9eb5613a2e32cbd`) already used by
  `coverage-main.yml` and the Dependabot-automerge workflow, and the
  `cobertura` format already produced by the bespoke slipcover
  invocation.
- `coverage-main.yml` is unchanged; it stays on `mode: upload`.
- The pull-request job's checkout already uses `fetch-depth: 0`
  (needed so `cs-coverage check` can reach the merge base), so no
  further checkout change was required.

## Validation

- [x] `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/ci.yml'))"` passes.
- [x] No workflow-contract tests pin `ci.yml`'s structure in this repo.
- [ ] CI: confirm the "Check coverage against CodeScene gates" step
      executes (not skipped) and succeeds, and the `CodeScene Code
      Coverage` check completes on this PR's head.
