### PR TITLE
Document mutation-testing workflow contract tests

### DIFF
--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -140,6 +140,69 @@ If a workflow's behaviour genuinely depends on a feature only present from a
 particular commit onwards, express that as a comment or a changelog note, not
 as a test assertion on the SHA string.
 
+## Mutation-testing workflow contract tests
+
+This repository runs scheduled, informational mutation testing through a thin
+caller workflow,
+[`.github/workflows/mutation-testing.yml`](../.github/workflows/mutation-testing.yml),
+which delegates to the shared reusable workflow
+`leynos/shared-actions/.github/workflows/mutation-mutmut.yml`. The heavy
+lifting — running `mutmut`, and summarizing survivors — lives in
+`shared-actions`; this repository carries only declarative configuration. The
+run is **informational only**: it never gates a pull request. Survivors are
+reported through the job summary and downloadable artefacts so they can be
+triaged into tests, not enforced as a blocking check. The mutation targets and
+test selection themselves are configured in `[tool.mutmut]` in
+`pyproject.toml` (`source_paths`, `pytest_add_cli_args_test_selection`,
+`also_copy`, `do_not_mutate`).
+
+The workflow runs in two modes. A **daily schedule** fires a change-scoped run
+that mutates only the source files touched within the detection window, so
+quiet days are cheap no-ops. A **manual dispatch** (the Actions "Run workflow"
+control) mutates the whole package; select a branch in that control to
+exercise a feature branch.
+
+The caller passes a small set of configuration inputs, each carrying intent:
+
+- `paths` — the change-detection glob (`lading/`) that decides whether a
+  scheduled run has anything to mutate, bounding the scheduled run to real
+  source changes.
+- `module-prefix-strip` — set to an empty string because `lading` uses a flat
+  package layout (the mutable source lives in `lading/`, not `src/`), so no
+  prefix needs to be stripped when translating changed files to module globs.
+
+The `uses:` reference pins the shared workflow to a full 40-character commit
+SHA rather than a branch or tag, so a force-push upstream cannot silently
+change what runs here. The contract test asserts only that the pin is a full
+commit SHA, not a particular value, so Dependabot bumps it automatically
+without any accompanying test edit.
+
+Because the caller is configuration rather than code, a contract test in
+[`tests/workflow_contracts/test_mutation_testing.py`](../tests/workflow_contracts/test_mutation_testing.py)
+pins the shape it must uphold, failing the pull request when the caller
+drifts — repointing the pin at a branch, widening the token scope, or
+dropping a configuration input — rather than letting the breakage surface
+only in a scheduled run. The test module self-skips when the workflow file is
+absent (mutmut copies the sources into a sandbox that omits `.github/`, so
+the contract test does not run there). Run it locally with:
+
+```bash
+uv run pytest tests/workflow_contracts/test_mutation_testing.py -v
+```
+
+The test validates:
+
+- the `uses:` reference targets `mutation-mutmut.yml` pinned to a full commit
+  SHA;
+- the `with:` block carries exactly the expected configuration (`paths` and
+  `module-prefix-strip` above);
+- job permissions are least-privilege (`contents: read`, `id-token: write`)
+  and the workflow-level default token scope is empty;
+- `concurrency` serializes runs per ref without cancelling one in progress;
+  and
+- the triggers keep the daily schedule and a plain `workflow_dispatch` with
+  no legacy branch input.
+
 ## Property-based testing
 
 [Hypothesis](https://hypothesis.readthedocs.io/) is a development dependency


### PR DESCRIPTION
## Summary

- Adds a new `## Mutation-testing workflow contract tests` section to
  [`docs/developers-guide.md`](docs/developers-guide.md), placed after the
  existing "Workflow pins and Dependabot" section and before
  "Property-based testing".
- Documents the thin caller
  [`.github/workflows/mutation-testing.yml`](.github/workflows/mutation-testing.yml),
  which delegates to `leynos/shared-actions/.github/workflows/mutation-mutmut.yml`
  (Permutation C: Python/mutmut), the `paths` and `module-prefix-strip`
  inputs it actually sets, and the `[tool.mutmut]` configuration in
  `pyproject.toml`.
- Documents the contract test
  [`tests/workflow_contracts/test_mutation_testing.py`](tests/workflow_contracts/test_mutation_testing.py):
  it is **shape-only** (a `USES_RE` regex asserting a full 40-hex commit SHA,
  not a hard-coded value, so Dependabot bumps freely), it self-skips via
  `pytestmark = pytest.mark.skipif(...)` when the workflow file is absent
  (mutmut's sandbox omits `.github/`), and it validates the `uses:` pin, the
  `with:` block, job/workflow permissions, `concurrency`, and triggers.
- Documents the local run command, verified to pass:

  ```bash
  uv run pytest tests/workflow_contracts/test_mutation_testing.py -v
  ```

  (6 passed). There is no `make test-workflow-contracts` target in this
  repository's `Makefile`, so the direct `pytest` invocation is documented
  instead.

## Roadmap / execplan note

Checked `docs/roadmap.md` and `docs/execplans/`; neither contains any
mutation-testing or contract-test tracking item, so no roadmap/execplan
tracking applies to this change.

## Table of contents note

`docs/developers-guide.md` has no internal table of contents or section
index near the top (it opens with prose and then runs straight into
headings), so no cross-link was added there. `docs/contents.md` is a
whole-repository documentation index and already links to
`developers-guide.md` as a single entry; it does not enumerate the guide's
internal sections, so it was left unchanged.

## Docs-lint result

Ran `make markdownlint` (the repository's Markdown lint + spelling gate,
which chains `spelling` then `markdownlint-cli2`). It initially caught two
en-GB-oxendict `-ise`/`-ize` violations introduced by the new section
(`summarising` -> `summarizing`, `serialises` -> `serializes`); both were
fixed and the gate now passes cleanly (0 errors). The Rust/Python test
suites were intentionally not run, per the docs-only scope of this change.

## Files changed

- [`docs/developers-guide.md`](docs/developers-guide.md)
