### PR TITLE
Clarify Python docstring guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,8 +18,24 @@
 - **Use consistent spelling and grammar.** Comments must use en-GB-oxendict
   ("-ize" / "-yse" / "-our") spelling and grammar, with the exception of
   references to external APIs.
-- **Illustrate with clear examples.** Function documentation must include clear
-  examples demonstrating usage and outcome. Test documentation should omit
+- **Document public APIs comprehensively.** Public functions, classes, and
+  methods must have comprehensive NumPy-style docstrings, including clear
+  examples that demonstrate usage and outcome where appropriate.
+- **Keep private helper docstrings concise.** Prefer single-line docstrings for
+  private helpers. When a private helper needs an explanatory paragraph,
+  inspect whether that need exposes conflated responsibilities, an unclear
+  command/query boundary, or another CQRS or cohesion failure:
+  - Split the helper when it performs distinct query and command
+    responsibilities or combines unrelated concerns.
+  - Extract a focused helper when doing so makes the invariant or boundary local
+    and simpler.
+  - Keep the helper intact when its responsibility is cohesive and the
+    explanation documents an unavoidable local constraint; retain the paragraph
+    in that case.
+- **Structure private helper docstrings selectively.** Use structured
+  NumPy-style sections for private helpers only when they describe non-obvious
+  behaviour.
+- **Keep test documentation meaningful.** Test documentation should omit
   examples that only restate the test logic.
 - **Keep file size manageable.** No single code file should be longer than 400
   lines. Long switch statements or dispatch tables should be broken up by


### PR DESCRIPTION
## Summary

- require comprehensive NumPy-style docstrings for public functions, classes, and methods
- prefer concise private-helper docstrings and document CQRS/cohesion review criteria
- reserve structured private sections for non-obvious behaviour and keep test documentation meaningful

## Validation

- `make fmt`
- `make check-fmt`
- `make markdownlint`
- `make nixie`
- `make test` (749 passed)
- `make typecheck`
- `make lint`

## Summary by Sourcery

Clarify Python docstring expectations for public and private helpers in AGENTS documentation.

Documentation:
- Require comprehensive NumPy-style docstrings for public Python APIs, with examples where appropriate.
- Encourage concise docstrings for private helpers and document CQRS/cohesion considerations when more explanation is needed.
- Restrict structured sections in private helper docstrings to non-obvious behaviour and clarify guidance for meaningful test documentation.