### PR TITLE
Clarify R503 terminal-return scope (#197)

### DIFF
--- a/.rules/python-return.md
+++ b/.rules/python-return.md
@@ -34,14 +34,15 @@ def func(x):
 def func(x):
     if x > 0:
         return x
-    return 0
+    return
 ```
 
-Ensure all branches explicitly return a value if any branch does.
+Ensure all branches return explicitly if any branch returns a value. Use a bare
+`return` when the other result is `None`, as required by R501.
 
 ______________________________________________________________________
 
-## R503 — Add an Explicit Return at the End
+## R503 — Add a Terminal Return When Another Path Returns a Value
 
 ```python
 # BAD:
@@ -54,10 +55,13 @@ def func(x):
 def func(x):
     if x > 0:
         return x
-    return -1
+    return
 ```
 
-Don't rely on implicit `None`—always return something at the end.
+Don't rely on implicit `None` if the function may return a value
+elsewhere—always return something at the end. This requirement does not apply
+to functions whose only possible result is `None`; they do not need a
+redundant bare `return` at the end.
 
 ______________________________________________________________________
 


### PR DESCRIPTION
## Summary

This branch clarifies the Python return guidance so R503 requires an explicit terminal return only when another control-flow path returns a value. It aligns R502 and R503 with R501 by using a bare `return` for an explicit `None` result, while allowing procedures whose only possible result is `None` to return implicitly.

Closes #197.

## Review walkthrough

- Review [`.rules/python-return.md`](https://github.com/leynos/lading/blob/f14723f8001d993e66540a5bf6405c197cbbd3ab/.rules/python-return.md) for the aligned R502 example, the narrowed R503 heading and explanation, and the explicit exemption for all-`None` procedures.

## Validation

- `make fmt`: passed; unrelated formatter churn was removed.
- `make markdownlint`: passed, including `.rules/python-return.md`.
- `make nixie`: passed.
- `git diff --check`: passed.
- `coderabbit review --agent`: completed with zero findings.

## References

- [Issue #197](https://github.com/leynos/lading/issues/197)
- [Lody session](https://lody.ai/leynos/sessions/1c208c90-febf-4654-9c2f-2f905858b1eb)

## Summary by Sourcery

Documentation:
- Update python-return rule documentation to distinguish functions that may return a non-None value from procedures whose only possible result is None, including examples using bare return and refined wording for R502 and R503.